### PR TITLE
Fix known issues

### DIFF
--- a/Lib/Sauce/KeyboardLayout.swift
+++ b/Lib/Sauce/KeyboardLayout.swift
@@ -17,7 +17,7 @@ final class KeyboardLayout {
     private var currentKeyboardLayoutInputSource: InputSource
     private var currentASCIICapableInputSouce: InputSource
     private var mappedKeyCodes = [InputSource: [Key: CGKeyCode]]()
-    private(set) var inputSources = [InputSource] ()
+    private(set) var inputSources = [InputSource]()
 
     private let distributedNotificationCenter: DistributedNotificationCenter
     private let notificationCenter: NotificationCenter

--- a/Lib/Sauce/KeyboardLayout.swift
+++ b/Lib/Sauce/KeyboardLayout.swift
@@ -17,7 +17,7 @@ final class KeyboardLayout {
     private var currentKeyboardLayoutInputSource: InputSource
     private var currentASCIICapableInputSouce: InputSource
     private var mappedKeyCodes = [InputSource: [Key: CGKeyCode]]()
-    private(set) var inputSources: [InputSource]
+    private(set) var inputSources = [InputSource] ()
 
     private let distributedNotificationCenter: DistributedNotificationCenter
     private let notificationCenter: NotificationCenter
@@ -28,8 +28,6 @@ final class KeyboardLayout {
         self.notificationCenter = notificationCenter
         self.currentKeyboardLayoutInputSource = InputSource(source: TISCopyCurrentKeyboardLayoutInputSource().takeUnretainedValue())
         self.currentASCIICapableInputSouce = InputSource(source: TISCopyCurrentASCIICapableKeyboardInputSource().takeUnretainedValue())
-        let tisInputSources = (TISCreateInputSourceList([:] as CFDictionary, false).takeUnretainedValue() as? [TISInputSource]) ?? []
-        self.inputSources = tisInputSources.map { InputSource(source: $0) }
         mappingInputSources()
         mappingKeyCodes(with: currentKeyboardLayoutInputSource)
         observeNotifications()
@@ -96,9 +94,12 @@ extension KeyboardLayout {
         self.currentASCIICapableInputSouce = InputSource(source: TISCopyCurrentASCIICapableKeyboardInputSource().takeUnretainedValue())
         guard source != currentKeyboardLayoutInputSource else { return }
         self.currentKeyboardLayoutInputSource = source
-        notificationCenter.post(name: .SauceSelectedKeyboardInputSourceChanged, object: nil)
-        guard mappedKeyCodes[source] == nil else { return }
+        guard mappedKeyCodes[source] == nil else {
+            notificationCenter.post(name: .SauceSelectedKeyboardInputSourceChanged, object: nil)
+            return
+        }
         mappingKeyCodes(with: source)
+        notificationCenter.post(name: .SauceSelectedKeyboardInputSourceChanged, object: nil)
     }
 
     @objc func enabledKeyboardInputSourcesChanged() {

--- a/Lib/Sauce/Sauce.swift
+++ b/Lib/Sauce/Sauce.swift
@@ -65,11 +65,11 @@ public extension Sauce {
 // MARK: - Characters
 public extension Sauce {
     func character(by keyCode: Int, carbonModifiers: Int) -> String? {
-        return currentCharacter(by: keyCode, carbonModifiers: carbonModifiers)
+        return currentCharacter(by: keyCode, carbonModifiers: carbonModifiers) ?? currentASCIICapableCharacter(by: keyCode, carbonModifiers: carbonModifiers)
     }
 
     func character(by keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
-        return currentCharacter(by: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
+        return character(by: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
     }
 
     func currentCharacter(by keyCode: Int, carbonModifiers: Int) -> String? {
@@ -77,7 +77,15 @@ public extension Sauce {
     }
 
     func currentCharacter(by keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
-        return layout.currentCharacter(by: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
+        return currentCharacter(by: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
+    }
+
+    func currentASCIICapableCharacter(by keyCode: Int, carbonModifiers: Int) -> String? {
+        return layout.currentASCIICapableCharacter(by: keyCode, carbonModifiers: carbonModifiers)
+    }
+
+    func currentASCIICapableCharacter(by keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
+        return currentASCIICapableCharacter(by: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
     }
 
     func character(with source: InputSource, keyCode: Int, carbonModifiers: Int) -> String? {
@@ -85,6 +93,6 @@ public extension Sauce {
     }
 
     func character(with source: InputSource, keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
-        return layout.character(with: source, keyCode: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
+        return character(with: source, keyCode: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
     }
 }

--- a/Lib/Sauce/Sauce.swift
+++ b/Lib/Sauce/Sauce.swift
@@ -32,37 +32,44 @@ public final class Sauce {
 
 }
 
+// MARK: - Input Sources
+public extension Sauce {
+    func currentInputSources() -> [InputSource] {
+        return layout.inputSources
+    }
+}
+
 // MARK: - KeyCodes
 public extension Sauce {
     func keyCode(by key: Key) -> CGKeyCode {
-        return currentKeyCode(by: key) ?? currentASCIICapableKeyCode(by: key) ?? key.QWERTYKeyCode
+        return currentKeyCode(by: key) ?? key.QWERTYKeyCode
     }
 
     func currentKeyCode(by key: Key) -> CGKeyCode? {
         return layout.currentKeyCode(by: key)
     }
 
-    func currentASCIICapableKeyCode(by key: Key) -> CGKeyCode? {
-        return layout.currentASCIICapableKeyCode(by: key)
+    func currentKeyCodes() -> [Key: CGKeyCode]? {
+        return layout.currentKeyCodes()
     }
 
     func keyCode(with source: InputSource, key: Key) -> CGKeyCode? {
         return layout.keyCode(with: source, key: key)
     }
 
-    func ASCIICapableInputSources() -> [InputSource] {
-        return layout.ASCIICapableInputSources
+    func keyCodes(with source: InputSource) -> [Key: CGKeyCode]? {
+        return layout.keyCodes(with: source)
     }
 }
 
 // MARK: - Characters
 public extension Sauce {
     func character(by keyCode: Int, carbonModifiers: Int) -> String? {
-        return currentCharacter(by: keyCode, carbonModifiers: carbonModifiers) ?? currentASCIICapableCharacter(by: keyCode, carbonModifiers: carbonModifiers)
+        return currentCharacter(by: keyCode, carbonModifiers: carbonModifiers)
     }
 
     func character(by keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
-        return currentCharacter(by: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers)) ?? currentASCIICapableCharacter(by: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
+        return currentCharacter(by: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
     }
 
     func currentCharacter(by keyCode: Int, carbonModifiers: Int) -> String? {
@@ -71,14 +78,6 @@ public extension Sauce {
 
     func currentCharacter(by keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
         return layout.currentCharacter(by: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
-    }
-
-    func currentASCIICapableCharacter(by keyCode: Int, carbonModifiers: Int) -> String? {
-        return layout.currentASCIICapableCharacter(by: keyCode, carbonModifiers: carbonModifiers)
-    }
-
-    func currentASCIICapableCharacter(by keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
-        return layout.currentASCIICapableCharacter(by: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
     }
 
     func character(with source: InputSource, keyCode: Int, carbonModifiers: Int) -> String? {

--- a/README.md
+++ b/README.md
@@ -38,29 +38,12 @@ Get the key code of the current input source.
 let keyCode = Sauce.shared.keyCode(by: .v)
 ```
 
-Get ASCII capable input source list.
-
-```swift
-let sources = Sauce.shared.ASCIICapableInputSources()
-```
-
-Get key code corresponding to input source.
-
-```swift
-let keyCode = Sauce.shared.keyCode(with: inputSource, key: .v)
-```
-
 ### Character
 Get the character of the current input source.
 
 ```swift
-let character = Sauce.shared.character(by: keyCode, carbonModifiers: modifiers)
-```
-
-However, since character strings can only be acquired in an ASCII Capable layout, **we recommend using this.**
-
-```swift
-let character = Sauce.shared.currentASCIICapableCharacter(by: keyCode, carbonModifiers: modifiers)
+let character = Sauce.shared.character(by: keyCode, carbonModifiers: shiftKey)
+let character = Sauce.shared.character(by: keyCode, cocoaModifiers: [.shift])
 ```
 
 ## Notification


### PR DESCRIPTION
##  Known issue1
When using `TISCopyCurrentASCIICapableKeyboardLayoutInputSource`, can obtain InputSource which always has keyboard layout. 
However, if Dvorak layout and Japanese(en) layout are set, Dvorak layout will always be returned, and incorrect values will be returned when using Japanese(en) keyboard as input source.

## Known issue2
When setting only Dvorak layout and Japanese layout, Dvorak layout is always set to `currentASCIICapableInputSouce`, so `currentASCIICapableKeyCode` and `currentASCIICapableCharacter` always returns to Dvorak layout.

## Known issue3
For layout like Japanese(en), `kTISPropertyUnicodeKeyLayoutData` returns NULL even if it is `ASCIICapableInputSource` Therefore, mapping is not performed when only Japanese is used as a keyboard.