### PR TITLE
ignore Xcode project built by SwiftPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 ## Build generated
 build/
 DerivedData/
+Sauce.xcodeproj/
 
 ## Various settings
 *.pbxuser
@@ -133,5 +134,3 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
-
-


### PR DESCRIPTION
The product of running `swift package generate-xcodeproj` doesn't need to be tracked by git