### PR TITLE
Filter out keyboard layouts with null ID before converting to InputSource

### DIFF
--- a/Lib/Sauce/KeyboardLayout.swift
+++ b/Lib/Sauce/KeyboardLayout.swift
@@ -133,11 +133,13 @@ extension KeyboardLayout {
     }
 }
 
-// MAKR: - Layouts
+// MARK: - Layouts
 private extension KeyboardLayout {
     func mappingInputSources() {
         guard let sources = TISCreateInputSourceList([:] as CFDictionary, false).takeUnretainedValue() as? [TISInputSource] else { return }
-        inputSources = sources.map { InputSource(source: $0) }
+        inputSources = sources.filter {
+            $0.value(forProperty: kTISPropertyInputSourceID, type: String.self) != nil
+        }.map { InputSource(source: $0) }
         inputSources.forEach { mappingKeyCodes(with: $0) }
     }
 


### PR DESCRIPTION
One of our users somehow got an installed keyboard source with a null ID
in their system, which lead to Sauce crashing any time it tried to fetch
their list of keyboard layouts.

This PR fixes the issue by first filtering out any keyboard sources that
don't have an input ID, before converting them to `InputSource`s and force
unwrapping the ID.

I couldn't think of a great way to add a test for this, since it would
require manually adding a funky keyboard source to the host system. I'm
open to any ideas!

```
Crashed: com.apple.main-thread
EXC_BAD_INSTRUCTION EXC_I386_INVOP 0x0000000000000000
0 Sauce $s5Sauce11InputSourceC6sourceACSo08TISInputC3Refa_tcfc + 832
1 Sauce $s5Sauce14KeyboardLayoutC19mappingInputSources33_8D36DAE444FDF4396578987D07DD0BB0LLyyF + 450
2 Sauce $s5Sauce14KeyboardLayoutC29distributedNotificationCenter012notificationF019modifierTransformerACSo013NSDistributedeF0C_So014NSNotificationF0CAA08ModifierI0CtcfcTf4gggn_n + 260
3 Sauce globalinit_33_8CF03999BA1F872D353EF450ABAE8350_func3 + 163
4 libdispatch.dylib _dispatch_client_callout + 8
5 libdispatch.dylib _dispatch_once_callout + 20
6 libswiftCore.dylib swift_once + 26
7 Sauce $s5SauceAAC6sharedABvau + 42 
```