### PR TITLE
Fix a crash when unable to get the keyboard source ID

### DIFF
--- a/Lib/Sauce/InputSource.swift
+++ b/Lib/Sauce/InputSource.swift
@@ -26,7 +26,9 @@ public final class InputSource {
 
     // MARK: - Initialize
     init(source: TISInputSource) {
-        self.id = source.value(forProperty: kTISPropertyInputSourceID, type: String.self)!
+        // There are some custom input sources that cannot get a SourceID, so if cannot get an SourceID, use a UUID.
+        // ref: https://github.com/Clipy/Sauce/pull/40
+        self.id = source.value(forProperty: kTISPropertyInputSourceID, type: String.self) ?? UUID().uuidString
         self.modeID = source.value(forProperty: kTISPropertyInputModeID, type: String.self)
         self.isASCIICapable = source.value(forProperty: kTISPropertyInputSourceIsASCIICapable, type: Bool.self) ?? false
         self.isEnableCapable = source.value(forProperty: kTISPropertyInputSourceIsEnableCapable, type: Bool.self) ?? false

--- a/Lib/Sauce/KeyboardLayout.swift
+++ b/Lib/Sauce/KeyboardLayout.swift
@@ -133,7 +133,7 @@ extension KeyboardLayout {
     }
 }
 
-// MAKR: - Layouts
+// MARK: - Layouts
 private extension KeyboardLayout {
     func mappingInputSources() {
         guard let sources = TISCreateInputSourceList([:] as CFDictionary, false).takeUnretainedValue() as? [TISInputSource] else { return }


### PR DESCRIPTION
Related: https://github.com/Clipy/Sauce/pull/40