### PR TITLE
Add #if os(macOS) macro

### DIFF
--- a/Lib/Sauce/InputSource.swift
+++ b/Lib/Sauce/InputSource.swift
@@ -8,6 +8,7 @@
 //  Copyright © 2015-2020 Clipy Project.
 //
 
+#if os(macOS)
 import Foundation
 import Carbon
 
@@ -56,3 +57,4 @@ extension InputSource: Equatable {
             lhs.modeID == rhs.modeID
     }
 }
+#endif

--- a/Lib/Sauce/Key.swift
+++ b/Lib/Sauce/Key.swift
@@ -8,6 +8,7 @@
 //  Copyright © 2015-2020 Clipy Project.
 //
 
+#if os(macOS)
 import Foundation
 import Carbon
 
@@ -561,3 +562,4 @@ public enum Key: String, Codable, Equatable {
     }
 
 }
+#endif

--- a/Lib/Sauce/KeyboardLayout.swift
+++ b/Lib/Sauce/KeyboardLayout.swift
@@ -8,6 +8,7 @@
 //  Copyright © 2015-2020 Clipy Project.
 //
 
+#if os(macOS)
 import Foundation
 import Carbon
 
@@ -186,3 +187,4 @@ private extension KeyboardLayout {
         return NSString(characters: &chars, length: length) as String
     }
 }
+#endif

--- a/Lib/Sauce/ModifierTransformer.swift
+++ b/Lib/Sauce/ModifierTransformer.swift
@@ -8,6 +8,7 @@
 //  Copyright © 2015-2020 Clipy Project.
 //
 
+#if os(macOS)
 import Foundation
 import Carbon
 import AppKit
@@ -44,3 +45,4 @@ extension ModifierTransformer {
         return convertedCarbonModifiers
     }
 }
+#endif

--- a/Lib/Sauce/NSMenuItem+Key.swift
+++ b/Lib/Sauce/NSMenuItem+Key.swift
@@ -8,6 +8,7 @@
 //  Copyright © 2015-2020 Clipy Project.
 //
 
+#if os(macOS)
 import AppKit
 
 extension NSMenuItem {
@@ -21,3 +22,4 @@ extension NSMenuItem {
         return Key(character: keyEquivalent, virtualKeyCode: nil)
     }
 }
+#endif

--- a/Lib/Sauce/Sauce.swift
+++ b/Lib/Sauce/Sauce.swift
@@ -8,6 +8,7 @@
 //  Copyright © 2015-2020 Clipy Project.
 //
 
+#if os(macOS)
 import Foundation
 import AppKit
 
@@ -112,3 +113,4 @@ extension Sauce {
         return character(with: source, keyCode: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
     }
 }
+#endif

--- a/Lib/Sauce/SpecialKeyCode.swift
+++ b/Lib/Sauce/SpecialKeyCode.swift
@@ -8,6 +8,7 @@
 //  Copyright © 2015-2020 Clipy Project.
 //
 
+#if os(macOS)
 import Foundation
 import Carbon
 
@@ -157,3 +158,4 @@ private extension Int {
         return String(format: "%C", self)
     }
 }
+#endif

--- a/Lib/Sauce/TISInputSource+Property.swift
+++ b/Lib/Sauce/TISInputSource+Property.swift
@@ -8,6 +8,7 @@
 //  Copyright © 2015-2020 Clipy Project.
 //
 
+#if os(macOS)
 import Foundation
 import Carbon
 
@@ -17,3 +18,4 @@ extension TISInputSource {
         return Unmanaged<AnyObject>.fromOpaque(value).takeUnretainedValue() as? T
     }
 }
+#endif


### PR DESCRIPTION
Thank you very much for developing such a useful library.

I'm working on a SwiftUI-based project that also supports iOS/macOS, and when I'm using Keyholder, everything is perfect, the only problem is that it breaks the preview of the iOS platform and keeps it in an uncompilable state.

After some experimentation, I found that I needed to add the #if os (macOS) macro to the Keyholder and associated Sauce/Magnet to explicitly tell the preview not to import and compile this part of the code on iOS platforms.

SwiftUI and cross-platform apps are becoming more and more common, and preview is a very powerful feature in SwiftUI. So I think this change is necessary.

Thanks!