### PR TITLE
Stabilize input source tests

### DIFF
--- a/Lib/SauceTests/Extensions/InputSource+Extensions.swift
+++ b/Lib/SauceTests/Extensions/InputSource+Extensions.swift
@@ -24,6 +24,7 @@ extension InputSource {
         return sourceList?.map { InputSource(source: $0) } ?? []
     }
 
+    @discardableResult
     func enable() -> Bool {
         TISEnableInputSource(source) == noErr
     }

--- a/Lib/SauceTests/KeyboardLayoutTests.swift
+++ b/Lib/SauceTests/KeyboardLayoutTests.swift
@@ -124,7 +124,7 @@ final class KeyboardLayoutTests {
         ),
         .bug("https://github.com/Clipy/Sauce/pull/15")
     )
-    func keyCodesJapanesesAndDvorakOnlyKeyboard() async {
+    func keyCodesJapanesesAndDvorakOnlyKeyboard() {
         InputSource.enabledInputSources
             .filter {
                 $0.id != Self.japaneseKeyboardID &&

--- a/Lib/SauceTests/KeyboardLayoutTests.swift
+++ b/Lib/SauceTests/KeyboardLayoutTests.swift
@@ -54,7 +54,7 @@ final class KeyboardLayoutTests {
     }
 
     @Test(
-        .inputSource(enableIDs: [dvorakKeyboardID], selectIDs: [dvorakKeyboardID])
+        .inputSource(enableIDs: [ABCKeyboardID, dvorakKeyboardID], selectIDs: [dvorakKeyboardID])
     )
     func keyCodesForDvorakKeyboard() {
         let notificationCenter = NotificationCenter()
@@ -80,7 +80,7 @@ final class KeyboardLayoutTests {
     }
 
     @Test(
-        .inputSource(enableIDs: [dvorakQWERTYKeyboardID], selectIDs: [dvorakQWERTYKeyboardID])
+        .inputSource(enableIDs: [ABCKeyboardID, dvorakQWERTYKeyboardID], selectIDs: [dvorakQWERTYKeyboardID])
     )
     func keyCodesForDvorakQWERTYKeyboard() {
         let notificationCenter = NotificationCenter()
@@ -120,12 +120,11 @@ final class KeyboardLayoutTests {
     @Test(
         .inputSource(
             enableIDs: [ABCKeyboardID, dvorakKeyboardID, kotoeriKeyboardID, japaneseKeyboardID],
-            selectIDs: [ABCKeyboardID, japaneseKeyboardID],
-            disableIDs: [ABCKeyboardID]
+            selectIDs: [ABCKeyboardID, japaneseKeyboardID]
         ),
         .bug("https://github.com/Clipy/Sauce/pull/15")
     )
-    func keyCodesJapanesesAndDvorakOnlyKeyboard() {
+    func keyCodesJapanesesAndDvorakOnlyKeyboard() async {
         InputSource.enabledInputSources
             .filter {
                 $0.id != Self.japaneseKeyboardID &&
@@ -159,11 +158,7 @@ final class KeyboardLayoutTests {
 
     @available(macOS 13, *)
     @Test(
-        .inputSource(
-            enableIDs: [ABCKeyboardID, dvorakKeyboardID],
-            selectIDs: [ABCKeyboardID],
-            disableIDs: [dvorakKeyboardID]
-        ),
+        .inputSource(enableIDs: [ABCKeyboardID], selectIDs: [ABCKeyboardID]),
         .timeLimit(.minutes(1))
     )
     func inputSourceChangedNotification() async throws {
@@ -198,7 +193,7 @@ final class KeyboardLayoutTests {
 
         #expect(dvorakInputSource.enable())
         #expect(dvorakInputSource.select())
-        try await Task.sleep(for: .milliseconds(500))
+        try await Task.sleep(for: .seconds(1))
         #expect(abcInputSource.select())
 
         #expect((await selectedSourceTask.value) == 2)
@@ -235,7 +230,7 @@ final class KeyboardLayoutTests {
         let dvorakInputSource = try #require(InputSource.allInputSources.first { $0.id == Self.dvorakKeyboardID })
 
         #expect(dvorakInputSource.select())
-        try await Task.sleep(for: .milliseconds(500))
+        try await Task.sleep(for: .seconds(1))
         #expect(abcInputSource.select())
 
         #expect((await keyCodesTask.value) == 2)

--- a/Lib/SauceTests/Traits/InputSourceTrait.swift
+++ b/Lib/SauceTests/Traits/InputSourceTrait.swift
@@ -8,6 +8,7 @@
 //  Copyright © 2015 Clipy Project.
 //
 
+import Carbon
 import Testing
 @testable import Sauce
 
@@ -15,13 +16,13 @@ import Testing
 struct InputSourceTrait: TestTrait, TestScoping {
     let enableIDs: [String]
     let selectIDs: [String]
-    let disableIDs: [String]
 
     func provideScope(
         for test: Test,
         testCase: Test.Case?,
         performing function: () async throws -> Void
     ) async throws {
+        let selectedInputSource = InputSource(source: TISCopyCurrentKeyboardLayoutInputSource().takeUnretainedValue())
         let allInputSources = InputSource.allInputSources
         let enabledInputSources = InputSource.enabledInputSources
         let enableInputSources = try enableIDs.map { id in
@@ -30,23 +31,8 @@ struct InputSourceTrait: TestTrait, TestScoping {
         let selectInputSources = try selectIDs.map { id in
             try #require(allInputSources.first { $0.id == id })
         }
-        let disableInputSources = try disableIDs.map { id in
-            try #require(allInputSources.first { $0.id == id })
-        }
-
-        let deferDisabledInputSources = enableInputSources.filter { inputSource in
-            enabledInputSources.map(\.id).contains(inputSource.id) == false
-        }
-        let deferEnabledInputSources = disableInputSources.filter { inputSource in
-            enabledInputSources.map(\.id).contains(inputSource.id) == true
-        }
-        defer {
-            deferEnabledInputSources.forEach { inputSource in
-                #expect(inputSource.enable())
-            }
-            deferDisabledInputSources.forEach { inputSource in
-                #expect(inputSource.disable())
-            }
+        let disableInputSources = enabledInputSources.filter { inputSource in
+            !enableIDs.contains(inputSource.id)
         }
 
         enableInputSources.forEach { inputSource in
@@ -59,6 +45,14 @@ struct InputSourceTrait: TestTrait, TestScoping {
             #expect(inputSource.disable())
         }
 
+        defer {
+            InputSource.enabledInputSources.filter { !enabledInputSources.contains($0) }
+                .forEach { $0.disable() }
+            enabledInputSources
+                .forEach { $0.enable() }
+            selectedInputSource.select()
+        }
+
         try await function()
     }
 }
@@ -66,9 +60,8 @@ struct InputSourceTrait: TestTrait, TestScoping {
 extension Trait where Self == InputSourceTrait {
     static func inputSource(
         enableIDs: [String] = [],
-        selectIDs: [String] = [],
-        disableIDs: [String] = []
+        selectIDs: [String] = []
     ) -> InputSourceTrait {
-        InputSourceTrait(enableIDs: enableIDs, selectIDs: selectIDs, disableIDs: disableIDs)
+        InputSourceTrait(enableIDs: enableIDs, selectIDs: selectIDs)
     }
 }


### PR DESCRIPTION
## Summary
- preserve and restore the previously selected input source in the test trait cleanup
- simplify input source setup so tests explicitly enable only the layouts they need
- increase notification test wait times to reduce timing-related flakes

## Testing
- `swift test`