### PR TITLE
Add unified Sauce modifiers API

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -21,10 +21,9 @@ class ViewController: NSViewController {
     @IBAction func buttonTapped(_ sender: Any) {
         guard let keyCode = Sauce.shared.currentKeyCode(for: .v) else { return }
         print(keyCode)
-        print(Sauce.shared.character(for: Int(keyCode), cocoaModifiers: []) as Any)
-        print(Sauce.shared.character(for: Int(keyCode), cocoaModifiers: .shift) as Any)
+        print(Sauce.shared.character(for: Int(keyCode), modifiers: .cocoa([])) as Any)
+        print(Sauce.shared.character(for: Int(keyCode), modifiers: .cocoa(.shift)) as Any)
         print(Sauce.shared.key(for: Int(keyCode)) as Any)
     }
 
 }
-

--- a/Lib/Sauce.xcodeproj/project.pbxproj
+++ b/Lib/Sauce.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		095EF0012456ED9A00174829 /* ModifierTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095EF0002456ED9A00174829 /* ModifierTransformer.swift */; };
 		50582477261C6F1F00AD2DD8 /* NSMenuItem+Key.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50582476261C6F1F00AD2DD8 /* NSMenuItem+Key.swift */; };
 		5058247B261C6FA400AD2DD8 /* NSMenuItem+KeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5058247A261C6FA400AD2DD8 /* NSMenuItem+KeyTests.swift */; };
+		C51EDBA82FE2E4AF004948B9 /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51EDBA62FE2E4AF004948B9 /* Deprecated.swift */; };
+		C51EDBA92FE2E4AF004948B9 /* SauceModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51EDBA72FE2E4AF004948B9 /* SauceModifiers.swift */; };
 		C57C16682F06CE9B00507D0B /* InputSourceTrait.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57C16672F06CE7A00507D0B /* InputSourceTrait.swift */; };
 		C57C166B2F06D20B00507D0B /* InputSource+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57C166A2F06D1FB00507D0B /* InputSource+Extensions.swift */; };
 		C5911E052FA8985500C06D99 /* KeyMappingModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5911E012FA8985500C06D99 /* KeyMappingModifiers.swift */; };
@@ -39,6 +41,8 @@
 		095EF0002456ED9A00174829 /* ModifierTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifierTransformer.swift; sourceTree = "<group>"; };
 		50582476261C6F1F00AD2DD8 /* NSMenuItem+Key.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSMenuItem+Key.swift"; sourceTree = "<group>"; };
 		5058247A261C6FA400AD2DD8 /* NSMenuItem+KeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMenuItem+KeyTests.swift"; sourceTree = "<group>"; };
+		C51EDBA62FE2E4AF004948B9 /* Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecated.swift; sourceTree = "<group>"; };
+		C51EDBA72FE2E4AF004948B9 /* SauceModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SauceModifiers.swift; sourceTree = "<group>"; };
 		C57C16672F06CE7A00507D0B /* InputSourceTrait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputSourceTrait.swift; sourceTree = "<group>"; };
 		C57C166A2F06D1FB00507D0B /* InputSource+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InputSource+Extensions.swift"; sourceTree = "<group>"; };
 		C5911E002FA8985500C06D99 /* KeyboardLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardLayout.swift; sourceTree = "<group>"; };
@@ -126,10 +130,12 @@
 				FAA41323210E2C730097D522 /* Sauce.h */,
 				FAA41324210E2C730097D522 /* Info.plist */,
 				FAA41364210E2D9B0097D522 /* Sauce.swift */,
+				C51EDBA72FE2E4AF004948B9 /* SauceModifiers.swift */,
 				FAA4136A210E33CB0097D522 /* InputSource.swift */,
 				FAA41366210E2EFB0097D522 /* Key.swift */,
 				095EF0002456ED9A00174829 /* ModifierTransformer.swift */,
 				50582476261C6F1F00AD2DD8 /* NSMenuItem+Key.swift */,
+				C51EDBA62FE2E4AF004948B9 /* Deprecated.swift */,
 			);
 			path = Sauce;
 			sourceTree = "<group>";
@@ -256,6 +262,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C51EDBA82FE2E4AF004948B9 /* Deprecated.swift in Sources */,
+				C51EDBA92FE2E4AF004948B9 /* SauceModifiers.swift in Sources */,
 				50582477261C6F1F00AD2DD8 /* NSMenuItem+Key.swift in Sources */,
 				FAA4136B210E33CC0097D522 /* InputSource.swift in Sources */,
 				FAA41365210E2D9B0097D522 /* Sauce.swift in Sources */,

--- a/Lib/Sauce/Deprecated.swift
+++ b/Lib/Sauce/Deprecated.swift
@@ -1,0 +1,144 @@
+//
+//  Deprecated.swift
+//
+//  Sauce
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+#if os(macOS)
+import AppKit
+import Carbon
+import Foundation
+
+// MARK: - Deprecated KeyCodes
+extension Sauce {
+    @available(*, deprecated, message: "Use keyCode(for:modifiers:) with .carbon(...).")
+    public func keyCode(for key: Key, carbonModifiers: Int) -> CGKeyCode {
+        return keyCode(for: key, modifiers: .carbon(carbonModifiers))
+    }
+
+    @available(*, deprecated, message: "Use keyCode(for:modifiers:) with .cocoa(...).")
+    public func keyCode(for key: Key, cocoaModifiers: NSEvent.ModifierFlags) -> CGKeyCode {
+        return keyCode(for: key, modifiers: .cocoa(cocoaModifiers))
+    }
+
+    @available(*, deprecated, message: "Use currentKeyCode(for:modifiers:) with .carbon(...).")
+    public func currentKeyCode(for key: Key, carbonModifiers: Int) -> CGKeyCode? {
+        return currentKeyCode(for: key, modifiers: .carbon(carbonModifiers))
+    }
+
+    @available(*, deprecated, message: "Use currentKeyCode(for:modifiers:) with .cocoa(...).")
+    public func currentKeyCode(for key: Key, cocoaModifiers: NSEvent.ModifierFlags) -> CGKeyCode? {
+        return currentKeyCode(for: key, modifiers: .cocoa(cocoaModifiers))
+    }
+
+    @available(*, deprecated, message: "Use currentKeyCodes(modifiers:) with .carbon(...).")
+    public func currentKeyCodes(carbonModifiers: Int) -> [Key: CGKeyCode]? {
+        return currentKeyCodes(modifiers: .carbon(carbonModifiers))
+    }
+
+    @available(*, deprecated, message: "Use currentKeyCodes(modifiers:) with .cocoa(...).")
+    public func currentKeyCodes(cocoaModifiers: NSEvent.ModifierFlags) -> [Key: CGKeyCode]? {
+        return currentKeyCodes(modifiers: .cocoa(cocoaModifiers))
+    }
+
+    @available(*, deprecated, message: "Use keyCode(with:key:modifiers:) with .carbon(...).")
+    public func keyCode(with source: InputSource, key: Key, carbonModifiers: Int) -> CGKeyCode? {
+        return keyCode(with: source, key: key, modifiers: .carbon(carbonModifiers))
+    }
+
+    @available(*, deprecated, message: "Use keyCode(with:key:modifiers:) with .cocoa(...).")
+    public func keyCode(with source: InputSource, key: Key, cocoaModifiers: NSEvent.ModifierFlags) -> CGKeyCode? {
+        return keyCode(with: source, key: key, modifiers: .cocoa(cocoaModifiers))
+    }
+
+    @available(*, deprecated, message: "Use keyCodes(with:modifiers:) with .carbon(...).")
+    public func keyCodes(with source: InputSource, carbonModifiers: Int) -> [Key: CGKeyCode]? {
+        return keyCodes(with: source, modifiers: .carbon(carbonModifiers))
+    }
+
+    @available(*, deprecated, message: "Use keyCodes(with:modifiers:) with .cocoa(...).")
+    public func keyCodes(with source: InputSource, cocoaModifiers: NSEvent.ModifierFlags) -> [Key: CGKeyCode]? {
+        return keyCodes(with: source, modifiers: .cocoa(cocoaModifiers))
+    }
+}
+
+// MARK: - Deprecated Key
+extension Sauce {
+    @available(*, deprecated, message: "Use key(for:modifiers:) with .carbon(...).")
+    public func key(for keyCode: Int, carbonModifiers: Int) -> Key? {
+        return key(for: keyCode, modifiers: .carbon(carbonModifiers))
+    }
+
+    @available(*, deprecated, message: "Use key(for:modifiers:) with .cocoa(...).")
+    public func key(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> Key? {
+        return key(for: keyCode, modifiers: .cocoa(cocoaModifiers))
+    }
+
+    @available(*, deprecated, message: "Use currentKey(for:modifiers:) with .carbon(...).")
+    public func currentKey(for keyCode: Int, carbonModifiers: Int) -> Key? {
+        return currentKey(for: keyCode, modifiers: .carbon(carbonModifiers))
+    }
+
+    @available(*, deprecated, message: "Use currentKey(for:modifiers:) with .cocoa(...).")
+    public func currentKey(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> Key? {
+        return currentKey(for: keyCode, modifiers: .cocoa(cocoaModifiers))
+    }
+
+    @available(*, deprecated, message: "Use key(with:keyCode:modifiers:) with .carbon(...).")
+    public func key(with source: InputSource, keyCode: Int, carbonModifiers: Int) -> Key? {
+        return key(with: source, keyCode: keyCode, modifiers: .carbon(carbonModifiers))
+    }
+
+    @available(*, deprecated, message: "Use key(with:keyCode:modifiers:) with .cocoa(...).")
+    public func key(with source: InputSource, keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> Key? {
+        return key(with: source, keyCode: keyCode, modifiers: .cocoa(cocoaModifiers))
+    }
+}
+
+// MARK: - Deprecated Characters
+extension Sauce {
+    @available(*, deprecated, message: "Use character(for:modifiers:) with .carbon(...).")
+    public func character(for keyCode: Int, carbonModifiers: Int) -> String? {
+        return character(for: keyCode, modifiers: .carbon(carbonModifiers))
+    }
+
+    @available(*, deprecated, message: "Use character(for:modifiers:) with .cocoa(...).")
+    public func character(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
+        return character(for: keyCode, modifiers: .cocoa(cocoaModifiers))
+    }
+
+    @available(*, deprecated, message: "Use currentCharacter(for:modifiers:) with .carbon(...).")
+    public func currentCharacter(for keyCode: Int, carbonModifiers: Int) -> String? {
+        return currentCharacter(for: keyCode, modifiers: .carbon(carbonModifiers))
+    }
+
+    @available(*, deprecated, message: "Use currentCharacter(for:modifiers:) with .cocoa(...).")
+    public func currentCharacter(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
+        return currentCharacter(for: keyCode, modifiers: .cocoa(cocoaModifiers))
+    }
+
+    @available(*, deprecated, message: "Use currentASCIICapableCharacter(for:modifiers:) with .carbon(...).")
+    public func currentASCIICapableCharacter(for keyCode: Int, carbonModifiers: Int) -> String? {
+        return currentASCIICapableCharacter(for: keyCode, modifiers: .carbon(carbonModifiers))
+    }
+
+    @available(*, deprecated, message: "Use currentASCIICapableCharacter(for:modifiers:) with .cocoa(...).")
+    public func currentASCIICapableCharacter(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
+        return currentASCIICapableCharacter(for: keyCode, modifiers: .cocoa(cocoaModifiers))
+    }
+
+    @available(*, deprecated, message: "Use character(with:keyCode:modifiers:) with .carbon(...).")
+    public func character(with source: InputSource, keyCode: Int, carbonModifiers: Int) -> String? {
+        return character(with: source, keyCode: keyCode, modifiers: .carbon(carbonModifiers))
+    }
+
+    @available(*, deprecated, message: "Use character(with:keyCode:modifiers:) with .cocoa(...).")
+    public func character(with source: InputSource, keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
+        return character(with: source, keyCode: keyCode, modifiers: .cocoa(cocoaModifiers))
+    }
+}
+#endif

--- a/Lib/Sauce/Deprecated.swift
+++ b/Lib/Sauce/Deprecated.swift
@@ -14,130 +14,130 @@ import Carbon
 import Foundation
 
 // MARK: - Deprecated KeyCodes
-extension Sauce {
+public extension Sauce {
     @available(*, deprecated, message: "Use keyCode(for:modifiers:) with .carbon(...).")
-    public func keyCode(for key: Key, carbonModifiers: Int) -> CGKeyCode {
+    func keyCode(for key: Key, carbonModifiers: Int) -> CGKeyCode {
         return keyCode(for: key, modifiers: .carbon(carbonModifiers))
     }
 
     @available(*, deprecated, message: "Use keyCode(for:modifiers:) with .cocoa(...).")
-    public func keyCode(for key: Key, cocoaModifiers: NSEvent.ModifierFlags) -> CGKeyCode {
+    func keyCode(for key: Key, cocoaModifiers: NSEvent.ModifierFlags) -> CGKeyCode {
         return keyCode(for: key, modifiers: .cocoa(cocoaModifiers))
     }
 
     @available(*, deprecated, message: "Use currentKeyCode(for:modifiers:) with .carbon(...).")
-    public func currentKeyCode(for key: Key, carbonModifiers: Int) -> CGKeyCode? {
+    func currentKeyCode(for key: Key, carbonModifiers: Int) -> CGKeyCode? {
         return currentKeyCode(for: key, modifiers: .carbon(carbonModifiers))
     }
 
     @available(*, deprecated, message: "Use currentKeyCode(for:modifiers:) with .cocoa(...).")
-    public func currentKeyCode(for key: Key, cocoaModifiers: NSEvent.ModifierFlags) -> CGKeyCode? {
+    func currentKeyCode(for key: Key, cocoaModifiers: NSEvent.ModifierFlags) -> CGKeyCode? {
         return currentKeyCode(for: key, modifiers: .cocoa(cocoaModifiers))
     }
 
     @available(*, deprecated, message: "Use currentKeyCodes(modifiers:) with .carbon(...).")
-    public func currentKeyCodes(carbonModifiers: Int) -> [Key: CGKeyCode]? {
+    func currentKeyCodes(carbonModifiers: Int) -> [Key: CGKeyCode]? {
         return currentKeyCodes(modifiers: .carbon(carbonModifiers))
     }
 
     @available(*, deprecated, message: "Use currentKeyCodes(modifiers:) with .cocoa(...).")
-    public func currentKeyCodes(cocoaModifiers: NSEvent.ModifierFlags) -> [Key: CGKeyCode]? {
+    func currentKeyCodes(cocoaModifiers: NSEvent.ModifierFlags) -> [Key: CGKeyCode]? {
         return currentKeyCodes(modifiers: .cocoa(cocoaModifiers))
     }
 
     @available(*, deprecated, message: "Use keyCode(with:key:modifiers:) with .carbon(...).")
-    public func keyCode(with source: InputSource, key: Key, carbonModifiers: Int) -> CGKeyCode? {
+    func keyCode(with source: InputSource, key: Key, carbonModifiers: Int) -> CGKeyCode? {
         return keyCode(with: source, key: key, modifiers: .carbon(carbonModifiers))
     }
 
     @available(*, deprecated, message: "Use keyCode(with:key:modifiers:) with .cocoa(...).")
-    public func keyCode(with source: InputSource, key: Key, cocoaModifiers: NSEvent.ModifierFlags) -> CGKeyCode? {
+    func keyCode(with source: InputSource, key: Key, cocoaModifiers: NSEvent.ModifierFlags) -> CGKeyCode? {
         return keyCode(with: source, key: key, modifiers: .cocoa(cocoaModifiers))
     }
 
     @available(*, deprecated, message: "Use keyCodes(with:modifiers:) with .carbon(...).")
-    public func keyCodes(with source: InputSource, carbonModifiers: Int) -> [Key: CGKeyCode]? {
+    func keyCodes(with source: InputSource, carbonModifiers: Int) -> [Key: CGKeyCode]? {
         return keyCodes(with: source, modifiers: .carbon(carbonModifiers))
     }
 
     @available(*, deprecated, message: "Use keyCodes(with:modifiers:) with .cocoa(...).")
-    public func keyCodes(with source: InputSource, cocoaModifiers: NSEvent.ModifierFlags) -> [Key: CGKeyCode]? {
+    func keyCodes(with source: InputSource, cocoaModifiers: NSEvent.ModifierFlags) -> [Key: CGKeyCode]? {
         return keyCodes(with: source, modifiers: .cocoa(cocoaModifiers))
     }
 }
 
 // MARK: - Deprecated Key
-extension Sauce {
+public extension Sauce {
     @available(*, deprecated, message: "Use key(for:modifiers:) with .carbon(...).")
-    public func key(for keyCode: Int, carbonModifiers: Int) -> Key? {
+    func key(for keyCode: Int, carbonModifiers: Int) -> Key? {
         return key(for: keyCode, modifiers: .carbon(carbonModifiers))
     }
 
     @available(*, deprecated, message: "Use key(for:modifiers:) with .cocoa(...).")
-    public func key(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> Key? {
+    func key(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> Key? {
         return key(for: keyCode, modifiers: .cocoa(cocoaModifiers))
     }
 
     @available(*, deprecated, message: "Use currentKey(for:modifiers:) with .carbon(...).")
-    public func currentKey(for keyCode: Int, carbonModifiers: Int) -> Key? {
+    func currentKey(for keyCode: Int, carbonModifiers: Int) -> Key? {
         return currentKey(for: keyCode, modifiers: .carbon(carbonModifiers))
     }
 
     @available(*, deprecated, message: "Use currentKey(for:modifiers:) with .cocoa(...).")
-    public func currentKey(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> Key? {
+    func currentKey(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> Key? {
         return currentKey(for: keyCode, modifiers: .cocoa(cocoaModifiers))
     }
 
     @available(*, deprecated, message: "Use key(with:keyCode:modifiers:) with .carbon(...).")
-    public func key(with source: InputSource, keyCode: Int, carbonModifiers: Int) -> Key? {
+    func key(with source: InputSource, keyCode: Int, carbonModifiers: Int) -> Key? {
         return key(with: source, keyCode: keyCode, modifiers: .carbon(carbonModifiers))
     }
 
     @available(*, deprecated, message: "Use key(with:keyCode:modifiers:) with .cocoa(...).")
-    public func key(with source: InputSource, keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> Key? {
+    func key(with source: InputSource, keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> Key? {
         return key(with: source, keyCode: keyCode, modifiers: .cocoa(cocoaModifiers))
     }
 }
 
 // MARK: - Deprecated Characters
-extension Sauce {
+public extension Sauce {
     @available(*, deprecated, message: "Use character(for:modifiers:) with .carbon(...).")
-    public func character(for keyCode: Int, carbonModifiers: Int) -> String? {
+    func character(for keyCode: Int, carbonModifiers: Int) -> String? {
         return character(for: keyCode, modifiers: .carbon(carbonModifiers))
     }
 
     @available(*, deprecated, message: "Use character(for:modifiers:) with .cocoa(...).")
-    public func character(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
+    func character(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
         return character(for: keyCode, modifiers: .cocoa(cocoaModifiers))
     }
 
     @available(*, deprecated, message: "Use currentCharacter(for:modifiers:) with .carbon(...).")
-    public func currentCharacter(for keyCode: Int, carbonModifiers: Int) -> String? {
+    func currentCharacter(for keyCode: Int, carbonModifiers: Int) -> String? {
         return currentCharacter(for: keyCode, modifiers: .carbon(carbonModifiers))
     }
 
     @available(*, deprecated, message: "Use currentCharacter(for:modifiers:) with .cocoa(...).")
-    public func currentCharacter(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
+    func currentCharacter(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
         return currentCharacter(for: keyCode, modifiers: .cocoa(cocoaModifiers))
     }
 
     @available(*, deprecated, message: "Use currentASCIICapableCharacter(for:modifiers:) with .carbon(...).")
-    public func currentASCIICapableCharacter(for keyCode: Int, carbonModifiers: Int) -> String? {
+    func currentASCIICapableCharacter(for keyCode: Int, carbonModifiers: Int) -> String? {
         return currentASCIICapableCharacter(for: keyCode, modifiers: .carbon(carbonModifiers))
     }
 
     @available(*, deprecated, message: "Use currentASCIICapableCharacter(for:modifiers:) with .cocoa(...).")
-    public func currentASCIICapableCharacter(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
+    func currentASCIICapableCharacter(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
         return currentASCIICapableCharacter(for: keyCode, modifiers: .cocoa(cocoaModifiers))
     }
 
     @available(*, deprecated, message: "Use character(with:keyCode:modifiers:) with .carbon(...).")
-    public func character(with source: InputSource, keyCode: Int, carbonModifiers: Int) -> String? {
+    func character(with source: InputSource, keyCode: Int, carbonModifiers: Int) -> String? {
         return character(with: source, keyCode: keyCode, modifiers: .carbon(carbonModifiers))
     }
 
     @available(*, deprecated, message: "Use character(with:keyCode:modifiers:) with .cocoa(...).")
-    public func character(with source: InputSource, keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
+    func character(with source: InputSource, keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
         return character(with: source, keyCode: keyCode, modifiers: .cocoa(cocoaModifiers))
     }
 }

--- a/Lib/Sauce/Sauce.swift
+++ b/Lib/Sauce/Sauce.swift
@@ -34,65 +34,65 @@ open class Sauce {
 }
 
 // MARK: - Input Sources
-extension Sauce {
-    public func currentInputSources() -> [InputSource] {
+public extension Sauce {
+    func currentInputSources() -> [InputSource] {
         return layout.inputSources
     }
 }
 
 // MARK: - KeyCodes
-extension Sauce {
-    public func keyCode(for key: Key, modifiers: SauceModifiers = .none) -> CGKeyCode {
+public extension Sauce {
+    func keyCode(for key: Key, modifiers: SauceModifiers = .none) -> CGKeyCode {
         return currentKeyCode(for: key, modifiers: modifiers) ?? key.QWERTYKeyCode
     }
 
-    public func currentKeyCode(for key: Key, modifiers: SauceModifiers = .none) -> CGKeyCode? {
+    func currentKeyCode(for key: Key, modifiers: SauceModifiers = .none) -> CGKeyCode? {
         return layout.currentKeyCode(for: key, carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 
-    public func currentKeyCodes(modifiers: SauceModifiers = .none) -> [Key: CGKeyCode]? {
+    func currentKeyCodes(modifiers: SauceModifiers = .none) -> [Key: CGKeyCode]? {
         return layout.currentKeyCodes(carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 
-    public func keyCode(with source: InputSource, key: Key, modifiers: SauceModifiers = .none) -> CGKeyCode? {
+    func keyCode(with source: InputSource, key: Key, modifiers: SauceModifiers = .none) -> CGKeyCode? {
         return layout.keyCode(with: source, key: key, carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 
-    public func keyCodes(with source: InputSource, modifiers: SauceModifiers = .none) -> [Key: CGKeyCode]? {
+    func keyCodes(with source: InputSource, modifiers: SauceModifiers = .none) -> [Key: CGKeyCode]? {
         return layout.keyCodes(with: source, carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 }
 
 // MARK: - Key
-extension Sauce {
-    public func key(for keyCode: Int, modifiers: SauceModifiers = .none) -> Key? {
+public extension Sauce {
+    func key(for keyCode: Int, modifiers: SauceModifiers = .none) -> Key? {
         return currentKey(for: keyCode, modifiers: modifiers) ?? Key(QWERTYKeyCode: keyCode)
     }
 
-    public func currentKey(for keyCode: Int, modifiers: SauceModifiers = .none) -> Key? {
+    func currentKey(for keyCode: Int, modifiers: SauceModifiers = .none) -> Key? {
         return layout.currentKey(for: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 
-    public func key(with source: InputSource, keyCode: Int, modifiers: SauceModifiers = .none) -> Key? {
+    func key(with source: InputSource, keyCode: Int, modifiers: SauceModifiers = .none) -> Key? {
         return layout.key(with: source, keyCode: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 }
 
 // MARK: - Characters
-extension Sauce {
-    public func character(for keyCode: Int, modifiers: SauceModifiers = .none) -> String? {
+public extension Sauce {
+    func character(for keyCode: Int, modifiers: SauceModifiers = .none) -> String? {
         return currentCharacter(for: keyCode, modifiers: modifiers) ?? currentASCIICapableCharacter(for: keyCode, modifiers: modifiers)
     }
 
-    public func currentCharacter(for keyCode: Int, modifiers: SauceModifiers = .none) -> String? {
+    func currentCharacter(for keyCode: Int, modifiers: SauceModifiers = .none) -> String? {
         return layout.currentCharacter(for: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 
-    public func currentASCIICapableCharacter(for keyCode: Int, modifiers: SauceModifiers = .none) -> String? {
+    func currentASCIICapableCharacter(for keyCode: Int, modifiers: SauceModifiers = .none) -> String? {
         return layout.currentASCIICapableCharacter(for: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 
-    public func character(with source: InputSource, keyCode: Int, modifiers: SauceModifiers = .none) -> String? {
+    func character(with source: InputSource, keyCode: Int, modifiers: SauceModifiers = .none) -> String? {
         return layout.character(with: source, keyCode: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 }

--- a/Lib/Sauce/Sauce.swift
+++ b/Lib/Sauce/Sauce.swift
@@ -42,106 +42,58 @@ extension Sauce {
 
 // MARK: - KeyCodes
 extension Sauce {
-    public func keyCode(for key: Key, carbonModifiers: Int = 0) -> CGKeyCode {
-        return currentKeyCode(for: key, carbonModifiers: carbonModifiers) ?? key.QWERTYKeyCode
+    public func keyCode(for key: Key, modifiers: SauceModifiers = .none) -> CGKeyCode {
+        return currentKeyCode(for: key, modifiers: modifiers) ?? key.QWERTYKeyCode
     }
 
-    public func keyCode(for key: Key, cocoaModifiers: NSEvent.ModifierFlags) -> CGKeyCode {
-        return keyCode(for: key, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
+    public func currentKeyCode(for key: Key, modifiers: SauceModifiers = .none) -> CGKeyCode? {
+        return layout.currentKeyCode(for: key, carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 
-    public func currentKeyCode(for key: Key, carbonModifiers: Int = 0) -> CGKeyCode? {
-        return layout.currentKeyCode(for: key, carbonModifiers: carbonModifiers)
+    public func currentKeyCodes(modifiers: SauceModifiers = .none) -> [Key: CGKeyCode]? {
+        return layout.currentKeyCodes(carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 
-    public func currentKeyCode(for key: Key, cocoaModifiers: NSEvent.ModifierFlags) -> CGKeyCode? {
-        return currentKeyCode(for: key, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
+    public func keyCode(with source: InputSource, key: Key, modifiers: SauceModifiers = .none) -> CGKeyCode? {
+        return layout.keyCode(with: source, key: key, carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 
-    public func currentKeyCodes(carbonModifiers: Int = 0) -> [Key: CGKeyCode]? {
-        return layout.currentKeyCodes(carbonModifiers: carbonModifiers)
-    }
-
-    public func currentKeyCodes(cocoaModifiers: NSEvent.ModifierFlags) -> [Key: CGKeyCode]? {
-        return currentKeyCodes(carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
-    }
-
-    public func keyCode(with source: InputSource, key: Key, carbonModifiers: Int = 0) -> CGKeyCode? {
-        return layout.keyCode(with: source, key: key, carbonModifiers: carbonModifiers)
-    }
-
-    public func keyCode(with source: InputSource, key: Key, cocoaModifiers: NSEvent.ModifierFlags) -> CGKeyCode? {
-        return keyCode(with: source, key: key, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
-    }
-
-    public func keyCodes(with source: InputSource, carbonModifiers: Int = 0) -> [Key: CGKeyCode]? {
-        return layout.keyCodes(with: source, carbonModifiers: carbonModifiers)
-    }
-
-    public func keyCodes(with source: InputSource, cocoaModifiers: NSEvent.ModifierFlags) -> [Key: CGKeyCode]? {
-        return keyCodes(with: source, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
+    public func keyCodes(with source: InputSource, modifiers: SauceModifiers = .none) -> [Key: CGKeyCode]? {
+        return layout.keyCodes(with: source, carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 }
 
 // MARK: - Key
 extension Sauce {
-    public func key(for keyCode: Int, carbonModifiers: Int = 0) -> Key? {
-        return currentKey(for: keyCode, carbonModifiers: carbonModifiers) ?? Key(QWERTYKeyCode: keyCode)
+    public func key(for keyCode: Int, modifiers: SauceModifiers = .none) -> Key? {
+        return currentKey(for: keyCode, modifiers: modifiers) ?? Key(QWERTYKeyCode: keyCode)
     }
 
-    public func key(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> Key? {
-        return key(for: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
+    public func currentKey(for keyCode: Int, modifiers: SauceModifiers = .none) -> Key? {
+        return layout.currentKey(for: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 
-    public func currentKey(for keyCode: Int, carbonModifiers: Int = 0) -> Key? {
-        return layout.currentKey(for: keyCode, carbonModifiers: carbonModifiers)
-    }
-
-    public func currentKey(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> Key? {
-        return currentKey(for: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
-    }
-
-    public func key(with source: InputSource, keyCode: Int, carbonModifiers: Int = 0) -> Key? {
-        return layout.key(with: source, keyCode: keyCode, carbonModifiers: carbonModifiers)
-    }
-
-    public func key(with source: InputSource, keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> Key? {
-        return key(with: source, keyCode: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
+    public func key(with source: InputSource, keyCode: Int, modifiers: SauceModifiers = .none) -> Key? {
+        return layout.key(with: source, keyCode: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 }
 
 // MARK: - Characters
 extension Sauce {
-    public func character(for keyCode: Int, carbonModifiers: Int) -> String? {
-        return currentCharacter(for: keyCode, carbonModifiers: carbonModifiers) ?? currentASCIICapableCharacter(for: keyCode, carbonModifiers: carbonModifiers)
+    public func character(for keyCode: Int, modifiers: SauceModifiers = .none) -> String? {
+        return currentCharacter(for: keyCode, modifiers: modifiers) ?? currentASCIICapableCharacter(for: keyCode, modifiers: modifiers)
     }
 
-    public func character(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
-        return character(for: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
+    public func currentCharacter(for keyCode: Int, modifiers: SauceModifiers = .none) -> String? {
+        return layout.currentCharacter(for: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 
-    public func currentCharacter(for keyCode: Int, carbonModifiers: Int) -> String? {
-        return layout.currentCharacter(for: keyCode, carbonModifiers: carbonModifiers)
+    public func currentASCIICapableCharacter(for keyCode: Int, modifiers: SauceModifiers = .none) -> String? {
+        return layout.currentASCIICapableCharacter(for: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 
-    public func currentCharacter(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
-        return currentCharacter(for: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
-    }
-
-    public func currentASCIICapableCharacter(for keyCode: Int, carbonModifiers: Int) -> String? {
-        return layout.currentASCIICapableCharacter(for: keyCode, carbonModifiers: carbonModifiers)
-    }
-
-    public func currentASCIICapableCharacter(for keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
-        return currentASCIICapableCharacter(for: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
-    }
-
-    public func character(with source: InputSource, keyCode: Int, carbonModifiers: Int) -> String? {
-        return layout.character(with: source, keyCode: keyCode, carbonModifiers: carbonModifiers)
-    }
-
-    public func character(with source: InputSource, keyCode: Int, cocoaModifiers: NSEvent.ModifierFlags) -> String? {
-        return character(with: source, keyCode: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: cocoaModifiers))
+    public func character(with source: InputSource, keyCode: Int, modifiers: SauceModifiers = .none) -> String? {
+        return layout.character(with: source, keyCode: keyCode, carbonModifiers: modifierTransformar.carbonFlags(from: modifiers))
     }
 }
 #endif

--- a/Lib/Sauce/SauceModifiers.swift
+++ b/Lib/Sauce/SauceModifiers.swift
@@ -1,0 +1,32 @@
+//
+//  SauceModifiers.swift
+//
+//  Sauce
+//  GitHub: https://github.com/clipy
+//  HP: https://clipy-app.com
+//
+//  Copyright © 2015-2026 Clipy Project.
+//
+
+#if os(macOS)
+import AppKit
+import Foundation
+
+public enum SauceModifiers {
+    case carbon(Int)
+    case cocoa(NSEvent.ModifierFlags)
+
+    public static let none: SauceModifiers = .carbon(0)
+}
+
+extension ModifierTransformer {
+    func carbonFlags(from modifiers: SauceModifiers) -> Int {
+        switch modifiers {
+        case let .carbon(carbonModifiers):
+            return carbonModifiers
+        case let .cocoa(cocoaModifiers):
+            return carbonFlags(from: cocoaModifiers)
+        }
+    }
+}
+#endif

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ let key = Sauce.shared.key(for: keyCode)
 Get the character of the current input source.
 
 ```swift
-let character = Sauce.shared.character(for: keyCode, carbonModifiers: shiftKey)
-let character = Sauce.shared.character(for: keyCode, cocoaModifiers: [.shift])
+let character = Sauce.shared.character(for: keyCode, modifiers: .carbon(shiftKey))
+let character = Sauce.shared.character(for: keyCode, modifiers: .cocoa([.shift]))
 ```
 
 ## Notification


### PR DESCRIPTION
## Summary

Adds `SauceModifiers` as the unified public modifier argument for Sauce APIs. The new enum accepts both Carbon integer flags and Cocoa `NSEvent.ModifierFlags`, while the implementation continues converting to Carbon flags at the API boundary.

Moves the previous `carbonModifiers:` and `cocoaModifiers:` overloads into `Deprecated.swift` with deprecation messages that point callers to the new `modifiers:` API.

Updates the README and example app to use the new modifier API.

## Notes

`swift test` passed locally before committing. SwiftPM still reports the existing unhandled `Info.plist` warnings for the package and test targets.