### PR TITLE
Support AppKit key equivalent characters

### DIFF
--- a/Sources/Sauce/Internal/SpecialKeyCode.swift
+++ b/Sources/Sauce/Internal/SpecialKeyCode.swift
@@ -311,4 +311,6 @@ internal enum SpecialKeyCode: CaseIterable {
             .map { String($0) }
     }
 }
+
+// swiftlint:enable identifier_name function_body_length type_body_length
 #endif

--- a/Sources/Sauce/Internal/SpecialKeyCode.swift
+++ b/Sources/Sauce/Internal/SpecialKeyCode.swift
@@ -13,7 +13,7 @@ import AppKit
 import Carbon
 import Foundation
 
-// swiftlint:disable identifier_name function_body_length
+// swiftlint:disable identifier_name function_body_length type_body_length
 
 /**
  *  keycodes for keys that are independent of keyboard layout
@@ -151,7 +151,7 @@ internal enum SpecialKeyCode: CaseIterable {
     // MARK: - Properties
     var character: String {
         switch self {
-        case .return: 
+        case .return:
             return "↩"
         case .tab:
             return "⇥"

--- a/Sources/Sauce/Internal/SpecialKeyCode.swift
+++ b/Sources/Sauce/Internal/SpecialKeyCode.swift
@@ -64,98 +64,171 @@ internal enum SpecialKeyCode {
     // MARK: - Initialize
     init?(keyCode: Int) {
         switch keyCode {
-        case kVK_Return: self = .return
-        case kVK_Tab: self = .tab
-        case kVK_Space: self = .space
-        case kVK_Delete: self = .delete
-        case kVK_Escape: self = .escape
-        case kVK_F17: self = .f17
-        case kVK_F18: self = .f18
-        case kVK_F19: self = .f19
-        case kVK_F20: self = .f20
-        case kVK_F5: self = .f5
-        case kVK_F6: self = .f6
-        case kVK_F7: self = .f7
-        case kVK_F3: self = .f3
-        case kVK_F8: self = .f8
-        case kVK_F9: self = .f9
-        case kVK_F11: self = .f11
-        case kVK_F13: self = .f13
-        case kVK_F16: self = .f16
-        case kVK_F14: self = .f14
-        case kVK_F10: self = .f10
-        case kVK_F12: self = .f12
-        case kVK_F15: self = .f15
-        case kVK_Help: self = .help
-        case kVK_Home: self = .home
-        case kVK_PageUp: self = .pageUp
-        case kVK_ForwardDelete: self = .forwardDelete
-        case kVK_F4: self = .f4
-        case kVK_End: self = .end
-        case kVK_F2: self = .f2
-        case kVK_PageDown: self = .pageDown
-        case kVK_F1: self = .f1
-        case kVK_LeftArrow: self = .leftArrow
-        case kVK_RightArrow: self = .rightArrow
-        case kVK_DownArrow: self = .downArrow
-        case kVK_UpArrow: self = .upArrow
-        case kVK_JIS_Eisu: self = .eisu
-        case kVK_JIS_Kana: self = .kana
-        case kVK_ANSI_KeypadClear: self = .keypadClear
-        case kVK_ANSI_KeypadEnter: self = .keypadEnter
-        default: return nil
+        case kVK_Return:
+            self = .return
+        case kVK_Tab:
+            self = .tab
+        case kVK_Space:
+            self = .space
+        case kVK_Delete:
+            self = .delete
+        case kVK_Escape:
+            self = .escape
+        case kVK_F17:
+            self = .f17
+        case kVK_F18:
+            self = .f18
+        case kVK_F19:
+            self = .f19
+        case kVK_F20:
+            self = .f20
+        case kVK_F5:
+            self = .f5
+        case kVK_F6:
+            self = .f6
+        case kVK_F7:
+            self = .f7
+        case kVK_F3:
+            self = .f3
+        case kVK_F8:
+            self = .f8
+        case kVK_F9:
+            self = .f9
+        case kVK_F11:
+            self = .f11
+        case kVK_F13:
+            self = .f13
+        case kVK_F16:
+            self = .f16
+        case kVK_F14:
+            self = .f14
+        case kVK_F10:
+            self = .f10
+        case kVK_F12:
+            self = .f12
+        case kVK_F15:
+            self = .f15
+        case kVK_Help:
+            self = .help
+        case kVK_Home:
+            self = .home
+        case kVK_PageUp:
+            self = .pageUp
+        case kVK_ForwardDelete:
+            self = .forwardDelete
+        case kVK_F4:
+            self = .f4
+        case kVK_End:
+            self = .end
+        case kVK_F2:
+            self = .f2
+        case kVK_PageDown:
+            self = .pageDown
+        case kVK_F1:
+            self = .f1
+        case kVK_LeftArrow:
+            self = .leftArrow
+        case kVK_RightArrow:
+            self = .rightArrow
+        case kVK_DownArrow:
+            self = .downArrow
+        case kVK_UpArrow:
+            self = .upArrow
+        case kVK_JIS_Eisu:
+            self = .eisu
+        case kVK_JIS_Kana:
+            self = .kana
+        case kVK_ANSI_KeypadClear:
+            self = .keypadClear
+        case kVK_ANSI_KeypadEnter:
+            self = .keypadEnter
+        default:
+            return nil
         }
     }
 
     // MARK: - Properties
     var character: String {
         switch self {
-        case .return: return 0x21A9.string // ↩
-        case .tab: return 0x21E5.string // ⇥
-        case .space: return 0x2423.string // ␣
-        case .delete: return 0x232B.string // ⌫
-        case .escape: return 0x238B.string // ⎋
-        case .f17: return "F17"
-        case .f18: return "F18"
-        case .f19: return "F19"
-        case .f20: return "F20"
-        case .f5: return "F5"
-        case .f6: return "F6"
-        case .f7: return "F7"
-        case .f3: return "F3"
-        case .f8: return "F8"
-        case .f9: return "F9"
-        case .f11: return "F11"
-        case .f13: return "F13"
-        case .f16: return "F16"
-        case .f14: return "F14"
-        case .f10: return "F10"
-        case .f12: return "F12"
-        case .f15: return "F15"
-        case .help: return "?⃝"
-        case .home: return 0x2196.string // ↖
-        case .pageUp: return 0x21DE.string // ⇞
-        case .forwardDelete: return 0x2326.string // ⌦
-        case .f4: return "F4"
-        case .end: return 0x2198.string // ↘
-        case .f2: return "F2"
-        case .pageDown: return 0x21DF.string // ⇟
-        case .f1: return "F1"
-        case .leftArrow: return 0x2190.string // ←
-        case .rightArrow: return 0x2192.string // →
-        case .downArrow: return 0x2193.string // ↓
-        case .upArrow: return 0x2191.string // ↑
-        case .eisu: return "英数"
-        case .kana: return "かな"
-        case .keypadClear: return 0x2327.string // ⌧
-        case .keypadEnter: return 0x2305.string // ⌅
+        case .return: 
+            return "↩"
+        case .tab:
+            return "⇥"
+        case .space:
+            return "␣"
+        case .delete:
+            return "⌫"
+        case .escape:
+            return "⎋"
+        case .f17:
+            return "F17"
+        case .f18:
+            return "F18"
+        case .f19:
+            return "F19"
+        case .f20:
+            return "F20"
+        case .f5:
+            return "F5"
+        case .f6:
+            return "F6"
+        case .f7:
+            return "F7"
+        case .f3:
+            return "F3"
+        case .f8:
+            return "F8"
+        case .f9:
+            return "F9"
+        case .f11:
+            return "F11"
+        case .f13:
+            return "F13"
+        case .f16:
+            return "F16"
+        case .f14:
+            return "F14"
+        case .f10:
+            return "F10"
+        case .f12:
+            return "F12"
+        case .f15:
+            return "F15"
+        case .help:
+            return "?⃝"
+        case .home:
+            return "↖"
+        case .pageUp:
+            return "⇞"
+        case .forwardDelete:
+            return "⌦"
+        case .f4:
+            return "F4"
+        case .end:
+            return "↘"
+        case .f2:
+            return "F2"
+        case .pageDown:
+            return "⇟"
+        case .f1:
+            return "F1"
+        case .leftArrow:
+            return "←"
+        case .rightArrow:
+            return "→"
+        case .downArrow:
+            return "↓"
+        case .upArrow:
+            return "↑"
+        case .eisu:
+            return "英数"
+        case .kana:
+            return "かな"
+        case .keypadClear:
+            return "⌧"
+        case .keypadEnter:
+            return "⌅"
         }
-    }
-}
-
-private extension Int {
-    var string: String {
-        return String(format: "%C", self)
     }
 }
 #endif

--- a/Sources/Sauce/Internal/SpecialKeyCode.swift
+++ b/Sources/Sauce/Internal/SpecialKeyCode.swift
@@ -9,6 +9,7 @@
 //
 
 #if os(macOS)
+import AppKit
 import Carbon
 import Foundation
 
@@ -20,7 +21,7 @@ import Foundation
  *
  *  UCKeyTranslate can not convert a layout-independent keycode to string.
  **/
-internal enum SpecialKeyCode {
+internal enum SpecialKeyCode: CaseIterable {
     case `return`
     case tab
     case space
@@ -229,6 +230,85 @@ internal enum SpecialKeyCode {
         case .keypadEnter:
             return "⌅"
         }
+    }
+    var appKitKeyEquivalents: [String] {
+        let characters: [Int]
+        switch self {
+        case .return:
+            characters = [NSNewlineCharacter, NSCarriageReturnCharacter]
+        case .tab:
+            characters = [NSTabCharacter, NSBackTabCharacter]
+        case .delete:
+            characters = [NSBackspaceCharacter, NSDeleteCharacter]
+        case .f17:
+            characters = [NSF17FunctionKey]
+        case .f18:
+            characters = [NSF18FunctionKey]
+        case .f19:
+            characters = [NSF19FunctionKey]
+        case .f20:
+            characters = [NSF20FunctionKey]
+        case .f5:
+            characters = [NSF5FunctionKey]
+        case .f6:
+            characters = [NSF6FunctionKey]
+        case .f7:
+            characters = [NSF7FunctionKey]
+        case .f3:
+            characters = [NSF3FunctionKey]
+        case .f8:
+            characters = [NSF8FunctionKey]
+        case .f9:
+            characters = [NSF9FunctionKey]
+        case .f11:
+            characters = [NSF11FunctionKey]
+        case .f13:
+            characters = [NSF13FunctionKey]
+        case .f16:
+            characters = [NSF16FunctionKey]
+        case .f14:
+            characters = [NSF14FunctionKey]
+        case .f10:
+            characters = [NSF10FunctionKey]
+        case .f12:
+            characters = [NSF12FunctionKey]
+        case .f15:
+            characters = [NSF15FunctionKey]
+        case .help:
+            characters = [NSHelpFunctionKey]
+        case .home:
+            characters = [NSHomeFunctionKey]
+        case .pageUp:
+            characters = [NSPageUpFunctionKey]
+        case .forwardDelete:
+            characters = [NSDeleteFunctionKey]
+        case .f4:
+            characters = [NSF4FunctionKey]
+        case .end:
+            characters = [NSEndFunctionKey]
+        case .f2:
+            characters = [NSF2FunctionKey]
+        case .pageDown:
+            characters = [NSPageDownFunctionKey]
+        case .f1:
+            characters = [NSF1FunctionKey]
+        case .leftArrow:
+            characters = [NSLeftArrowFunctionKey]
+        case .rightArrow:
+            characters = [NSRightArrowFunctionKey]
+        case .downArrow:
+            characters = [NSDownArrowFunctionKey]
+        case .upArrow:
+            characters = [NSUpArrowFunctionKey]
+        case .keypadClear:
+            characters = [NSClearLineFunctionKey]
+        case .keypadEnter:
+            characters = [NSEnterCharacter]
+        case .space, .escape, .eisu, .kana:
+            characters = []
+        }
+        return characters.compactMap { UnicodeScalar($0) }
+            .map { String($0) }
     }
 }
 #endif

--- a/Sources/Sauce/Key.swift
+++ b/Sources/Sauce/Key.swift
@@ -131,433 +131,759 @@ public enum Key: String, Codable, Equatable, Sendable {
     public init?(character: String, virtualKeyCode: Int?) {
         let lowercasedString = character.lowercased()
         switch lowercasedString {
-        case "a": self = .a
-        case "s": self = .s
-        case "d": self = .d
-        case "f": self = .f
-        case "h": self = .h
-        case "g": self = .g
-        case "z": self = .z
-        case "x": self = .x
-        case "c": self = .c
-        case "v": self = .v
-        case "b": self = .b
-        case "q": self = .q
-        case "w": self = .w
-        case "e": self = .e
-        case "r": self = .r
-        case "y": self = .y
-        case "t": self = .t
+        case "a":
+            self = .a
+        case "s":
+            self = .s
+        case "d":
+            self = .d
+        case "f":
+            self = .f
+        case "h":
+            self = .h
+        case "g":
+            self = .g
+        case "z":
+            self = .z
+        case "x":
+            self = .x
+        case "c":
+            self = .c
+        case "v":
+            self = .v
+        case "b":
+            self = .b
+        case "q":
+            self = .q
+        case "w":
+            self = .w
+        case "e":
+            self = .e
+        case "r":
+            self = .r
+        case "y":
+            self = .y
+        case "t":
+            self = .t
         case "1" where virtualKeyCode != kVK_ANSI_Keypad1,
-             "one" where virtualKeyCode != kVK_ANSI_Keypad1: self = .one
+            "one" where virtualKeyCode != kVK_ANSI_Keypad1:
+            self = .one
         case "2" where virtualKeyCode != kVK_ANSI_Keypad2,
-             "two" where virtualKeyCode != kVK_ANSI_Keypad2: self = .two
+            "two" where virtualKeyCode != kVK_ANSI_Keypad2:
+            self = .two
         case "3" where virtualKeyCode != kVK_ANSI_Keypad3,
-             "three" where virtualKeyCode != kVK_ANSI_Keypad3: self = .three
+            "three" where virtualKeyCode != kVK_ANSI_Keypad3:
+            self = .three
         case "4" where virtualKeyCode != kVK_ANSI_Keypad4,
-             "four" where virtualKeyCode != kVK_ANSI_Keypad4: self = .four
+            "four" where virtualKeyCode != kVK_ANSI_Keypad4:
+            self = .four
         case "6" where virtualKeyCode != kVK_ANSI_Keypad6,
-             "six" where virtualKeyCode != kVK_ANSI_Keypad6: self = .six
+            "six" where virtualKeyCode != kVK_ANSI_Keypad6:
+            self = .six
         case "5" where virtualKeyCode != kVK_ANSI_Keypad5,
-             "five" where virtualKeyCode != kVK_ANSI_Keypad5: self = .five
+            "five" where virtualKeyCode != kVK_ANSI_Keypad5:
+            self = .five
         case "equal" where virtualKeyCode != kVK_ANSI_KeypadEquals,
-             "=" where virtualKeyCode != kVK_ANSI_KeypadEquals: self = .equal
+            "=" where virtualKeyCode != kVK_ANSI_KeypadEquals:
+            self = .equal
         case "9" where virtualKeyCode != kVK_ANSI_Keypad9,
-             "nine" where virtualKeyCode != kVK_ANSI_Keypad9: self = .nine
+            "nine" where virtualKeyCode != kVK_ANSI_Keypad9:
+            self = .nine
         case "7" where virtualKeyCode != kVK_ANSI_Keypad7,
-             "seven" where virtualKeyCode != kVK_ANSI_Keypad7: self = .seven
+            "seven" where virtualKeyCode != kVK_ANSI_Keypad7:
+            self = .seven
         case "minus" where virtualKeyCode != kVK_ANSI_KeypadMinus,
-             "-" where virtualKeyCode != kVK_ANSI_KeypadMinus: self = .minus
+            "-" where virtualKeyCode != kVK_ANSI_KeypadMinus:
+            self = .minus
         case "8" where virtualKeyCode != kVK_ANSI_Keypad8,
-             "eight" where virtualKeyCode != kVK_ANSI_Keypad8: self = .eight
+            "eight" where virtualKeyCode != kVK_ANSI_Keypad8:
+            self = .eight
         case "0" where virtualKeyCode != kVK_ANSI_Keypad0,
-             "zero" where virtualKeyCode != kVK_ANSI_Keypad0: self = .zero
+            "zero" where virtualKeyCode != kVK_ANSI_Keypad0:
+            self = .zero
         case "rightbracket",
-             "]": self = .rightBracket
-        case "o": self = .o
-        case "u": self = .u
+            "]":
+            self = .rightBracket
+        case "o":
+            self = .o
+        case "u":
+            self = .u
         case "leftbracket",
-             "[": self = .leftBracket
-        case "i": self = .i
-        case "p": self = .p
-        case "l": self = .l
-        case "j": self = .j
+            "[":
+            self = .leftBracket
+        case "i":
+            self = .i
+        case "p":
+            self = .p
+        case "l":
+            self = .l
+        case "j":
+            self = .j
         case "quote",
-             "'": self = .quote
-        case "k": self = .k
+            "'":
+            self = .quote
+        case "k":
+            self = .k
         case "semicolon",
-             ";": self = .semicolon
+            ";":
+            self = .semicolon
         case "backslash",
-             "\\": self = .backslash
+            "\\":
+            self = .backslash
         case "comma",
-             "," where virtualKeyCode != kVK_JIS_KeypadComma: self = .comma
+            "," where virtualKeyCode != kVK_JIS_KeypadComma:
+            self = .comma
         case "slash" where virtualKeyCode != kVK_ANSI_KeypadDivide,
-             "/" where virtualKeyCode != kVK_ANSI_KeypadDivide: self = .slash
-        case "n": self = .n
-        case "m": self = .m
+            "/" where virtualKeyCode != kVK_ANSI_KeypadDivide:
+            self = .slash
+        case "n":
+            self = .n
+        case "m":
+            self = .m
         case "period",
-             "." where virtualKeyCode != kVK_ANSI_KeypadDecimal: self = .period
+            "." where virtualKeyCode != kVK_ANSI_KeypadDecimal:
+            self = .period
         case "grave",
-             "`": self = .grave
+            "`":
+            self = .grave
         case "keypaddecimal",
-             "." where virtualKeyCode == kVK_ANSI_KeypadDecimal: self = .keypadDecimal
+            "." where virtualKeyCode == kVK_ANSI_KeypadDecimal:
+            self = .keypadDecimal
         case "keypadmultiply",
-             "*": self = .keypadMultiply
+            "*":
+            self = .keypadMultiply
         case "keypadplus",
-             "+": self = .keypadPlus
+            "+":
+            self = .keypadPlus
         case "keypadclear",
-             SpecialKeyCode.keypadClear.character.lowercased(): self = .keypadClear
+            SpecialKeyCode.keypadClear.character.lowercased():
+            self = .keypadClear
         case "keypaddivide",
-             "/" where virtualKeyCode == kVK_ANSI_KeypadDivide: self = .keypadDivide
+            "/" where virtualKeyCode == kVK_ANSI_KeypadDivide:
+            self = .keypadDivide
         case "keypadenter",
-             SpecialKeyCode.keypadEnter.character.lowercased(): self = .keypadEnter
+            SpecialKeyCode.keypadEnter.character.lowercased():
+            self = .keypadEnter
         case "keypadminus",
-             "-" where virtualKeyCode == kVK_ANSI_KeypadMinus: self = .keypadMinus
+            "-" where virtualKeyCode == kVK_ANSI_KeypadMinus:
+            self = .keypadMinus
         case "keypadequals",
-             "=" where virtualKeyCode == kVK_ANSI_KeypadEquals: self = .keypadEquals
+            "=" where virtualKeyCode == kVK_ANSI_KeypadEquals:
+            self = .keypadEquals
         case "keypad0",
-             "keypadzero",
-             "0" where virtualKeyCode == kVK_ANSI_Keypad0: self = .keypadZero
+            "keypadzero",
+            "0" where virtualKeyCode == kVK_ANSI_Keypad0:
+            self = .keypadZero
         case "keypad1",
-             "keypadone",
-             "1" where virtualKeyCode == kVK_ANSI_Keypad1: self = .keypadOne
+            "keypadone",
+            "1" where virtualKeyCode == kVK_ANSI_Keypad1:
+            self = .keypadOne
         case "keypad2",
-             "keypadtwo",
-             "2" where virtualKeyCode == kVK_ANSI_Keypad2: self = .keypadTwo
+            "keypadtwo",
+            "2" where virtualKeyCode == kVK_ANSI_Keypad2:
+            self = .keypadTwo
         case "keypad3",
-             "keypadthree",
-             "3" where virtualKeyCode == kVK_ANSI_Keypad3: self = .keypadThree
+            "keypadthree",
+            "3" where virtualKeyCode == kVK_ANSI_Keypad3:
+            self = .keypadThree
         case "keypad4",
-             "keypadfour",
-             "4" where virtualKeyCode == kVK_ANSI_Keypad4: self = .keypadFour
+            "keypadfour",
+            "4" where virtualKeyCode == kVK_ANSI_Keypad4:
+            self = .keypadFour
         case "keypad5",
-             "keypadfive",
-             "5" where virtualKeyCode == kVK_ANSI_Keypad5: self = .keypadFive
+            "keypadfive",
+            "5" where virtualKeyCode == kVK_ANSI_Keypad5:
+            self = .keypadFive
         case "keypad6",
-             "keypadsix",
-             "6" where virtualKeyCode == kVK_ANSI_Keypad6: self = .keypadSix
+            "keypadsix",
+            "6" where virtualKeyCode == kVK_ANSI_Keypad6:
+            self = .keypadSix
         case "keypad7",
-             "keypadseven",
-             "7" where virtualKeyCode == kVK_ANSI_Keypad7: self = .keypadSeven
+            "keypadseven",
+            "7" where virtualKeyCode == kVK_ANSI_Keypad7:
+            self = .keypadSeven
         case "keypad8",
-             "keypadeight",
-             "8" where virtualKeyCode == kVK_ANSI_Keypad8: self = .keypadEight
+            "keypadeight",
+            "8" where virtualKeyCode == kVK_ANSI_Keypad8:
+            self = .keypadEight
         case "keypad9",
-             "keypadnine",
-             "9" where virtualKeyCode == kVK_ANSI_Keypad9: self = .keypadNine
+            "keypadnine",
+            "9" where virtualKeyCode == kVK_ANSI_Keypad9:
+            self = .keypadNine
         case "return",
-             "\r", // NSMenuItem.keyEquivalent for return key
-             "\n",
-             SpecialKeyCode.return.character.lowercased(): self = .return
+            "\r", // NSMenuItem.keyEquivalent for return key
+            "\n",
+            SpecialKeyCode.return.character.lowercased():
+            self = .return
         case "tab",
-             SpecialKeyCode.tab.character.lowercased(): self = .tab
+            SpecialKeyCode.tab.character.lowercased():
+            self = .tab
         case "space",
-             SpecialKeyCode.space.character.lowercased(): self = .space
+            SpecialKeyCode.space.character.lowercased():
+            self = .space
         case "delete",
-             SpecialKeyCode.delete.character.lowercased(): self = .delete
+            SpecialKeyCode.delete.character.lowercased():
+            self = .delete
         case "escape",
-             SpecialKeyCode.escape.character.lowercased(): self = .escape
+            SpecialKeyCode.escape.character.lowercased():
+            self = .escape
         case "f17",
-             SpecialKeyCode.f17.character.lowercased(): self = .f17
+            SpecialKeyCode.f17.character.lowercased():
+            self = .f17
         case "f18",
-             SpecialKeyCode.f18.character.lowercased(): self = .f18
+            SpecialKeyCode.f18.character.lowercased():
+            self = .f18
         case "f19",
-             SpecialKeyCode.f19.character.lowercased(): self = .f19
+            SpecialKeyCode.f19.character.lowercased():
+            self = .f19
         case "f20",
-             SpecialKeyCode.f20.character.lowercased(): self = .f20
+            SpecialKeyCode.f20.character.lowercased():
+            self = .f20
         case "f5",
-             SpecialKeyCode.f5.character.lowercased(): self = .f5
+            SpecialKeyCode.f5.character.lowercased():
+            self = .f5
         case "f6",
-             SpecialKeyCode.f6.character.lowercased(): self = .f6
+            SpecialKeyCode.f6.character.lowercased():
+            self = .f6
         case "f7",
-             SpecialKeyCode.f7.character.lowercased(): self = .f7
+            SpecialKeyCode.f7.character.lowercased():
+            self = .f7
         case "f3",
-             SpecialKeyCode.f3.character.lowercased(): self = .f3
+            SpecialKeyCode.f3.character.lowercased():
+            self = .f3
         case "f8",
-             SpecialKeyCode.f8.character.lowercased(): self = .f8
+            SpecialKeyCode.f8.character.lowercased():
+            self = .f8
         case "f9",
-             SpecialKeyCode.f9.character.lowercased(): self = .f9
+            SpecialKeyCode.f9.character.lowercased():
+            self = .f9
         case "f11",
-             SpecialKeyCode.f11.character.lowercased(): self = .f11
+            SpecialKeyCode.f11.character.lowercased():
+            self = .f11
         case "f13",
-             SpecialKeyCode.f13.character.lowercased(): self = .f13
+            SpecialKeyCode.f13.character.lowercased():
+            self = .f13
         case "f16",
-             SpecialKeyCode.f16.character.lowercased(): self = .f16
+            SpecialKeyCode.f16.character.lowercased():
+            self = .f16
         case "f14",
-             SpecialKeyCode.f14.character.lowercased(): self = .f14
+            SpecialKeyCode.f14.character.lowercased():
+            self = .f14
         case "f10",
-             SpecialKeyCode.f10.character.lowercased(): self = .f10
+            SpecialKeyCode.f10.character.lowercased():
+            self = .f10
         case "f12",
-             SpecialKeyCode.f12.character.lowercased(): self = .f12
+            SpecialKeyCode.f12.character.lowercased():
+            self = .f12
         case "f15",
-             SpecialKeyCode.f15.character.lowercased(): self = .f15
+            SpecialKeyCode.f15.character.lowercased():
+            self = .f15
         case "help",
-             SpecialKeyCode.help.character.lowercased(): self = .help
+            SpecialKeyCode.help.character.lowercased():
+            self = .help
         case "home",
-             SpecialKeyCode.home.character.lowercased(): self = .home
+            SpecialKeyCode.home.character.lowercased():
+            self = .home
         case "pageup",
-             SpecialKeyCode.pageUp.character.lowercased(): self = .pageUp
+            SpecialKeyCode.pageUp.character.lowercased():
+            self = .pageUp
         case "forwarddelete",
-             SpecialKeyCode.forwardDelete.character.lowercased(): self = .forwardDelete
+            SpecialKeyCode.forwardDelete.character.lowercased():
+            self = .forwardDelete
         case "f4",
-             SpecialKeyCode.f4.character.lowercased(): self = .f4
+            SpecialKeyCode.f4.character.lowercased():
+            self = .f4
         case "end",
-             SpecialKeyCode.end.character.lowercased(): self = .end
+            SpecialKeyCode.end.character.lowercased():
+            self = .end
         case "f2",
-             SpecialKeyCode.f2.character.lowercased(): self = .f2
+            SpecialKeyCode.f2.character.lowercased():
+            self = .f2
         case "pagedown",
-             SpecialKeyCode.pageDown.character.lowercased(): self = .pageDown
+            SpecialKeyCode.pageDown.character.lowercased():
+            self = .pageDown
         case "f1",
-             SpecialKeyCode.f1.character.lowercased(): self = .f1
+            SpecialKeyCode.f1.character.lowercased():
+            self = .f1
         case "leftarrow",
-             SpecialKeyCode.leftArrow.character.lowercased(): self = .leftArrow
+            SpecialKeyCode.leftArrow.character.lowercased():
+            self = .leftArrow
         case "rightarrow",
-             SpecialKeyCode.rightArrow.character.lowercased(): self = .rightArrow
+            SpecialKeyCode.rightArrow.character.lowercased():
+            self = .rightArrow
         case "downarrow",
-             SpecialKeyCode.downArrow.character.lowercased(): self = .downArrow
+            SpecialKeyCode.downArrow.character.lowercased():
+            self = .downArrow
         case "uparrow",
-             SpecialKeyCode.upArrow.character.lowercased(): self = .upArrow
-        case "¥": self = .yen
-        case "_": self = .underscore
-        case "," where virtualKeyCode == kVK_JIS_KeypadComma: self = .keypadComma
+            SpecialKeyCode.upArrow.character.lowercased():
+            self = .upArrow
+        case "¥":
+            self = .yen
+        case "_":
+            self = .underscore
+        case "," where virtualKeyCode == kVK_JIS_KeypadComma:
+            self = .keypadComma
         case "英数",
-             SpecialKeyCode.eisu.character.lowercased(): self = .eisu
+            SpecialKeyCode.eisu.character.lowercased():
+            self = .eisu
         case "かな",
-             SpecialKeyCode.kana.character.lowercased(): self = .kana
-        case "@": self = .atSign
-        case "^": self = .caret
-        case ":": self = .colon
-        case "§": self = .section
-        default: return nil
+            SpecialKeyCode.kana.character.lowercased():
+            self = .kana
+        case "@":
+            self = .atSign
+        case "^":
+            self = .caret
+        case ":":
+            self = .colon
+        case "§":
+            self = .section
+        default:
+            return nil
         }
     }
 
     public init?(QWERTYKeyCode keyCode: Int) {
         switch keyCode {
-        case kVK_ANSI_A: self = .a
-        case kVK_ANSI_S: self = .s
-        case kVK_ANSI_D: self = .d
-        case kVK_ANSI_F: self = .f
-        case kVK_ANSI_H: self = .h
-        case kVK_ANSI_G: self = .g
-        case kVK_ANSI_Z: self = .z
-        case kVK_ANSI_X: self = .x
-        case kVK_ANSI_C: self = .c
-        case kVK_ANSI_V: self = .v
-        case kVK_ANSI_B: self = .b
-        case kVK_ANSI_Q: self = .q
-        case kVK_ANSI_W: self = .w
-        case kVK_ANSI_E: self = .e
-        case kVK_ANSI_R: self = .r
-        case kVK_ANSI_Y: self = .y
-        case kVK_ANSI_T: self = .t
-        case kVK_ANSI_1: self = .one
-        case kVK_ANSI_2: self = .two
-        case kVK_ANSI_3: self = .three
-        case kVK_ANSI_4: self = .four
-        case kVK_ANSI_6: self = .six
-        case kVK_ANSI_5: self = .five
-        case kVK_ANSI_Equal: self = .equal
-        case kVK_ANSI_9: self = .nine
-        case kVK_ANSI_7: self = .seven
-        case kVK_ANSI_Minus: self = .minus
-        case kVK_ANSI_8: self = .eight
-        case kVK_ANSI_0: self = .zero
-        case kVK_ANSI_RightBracket: self = .rightBracket
-        case kVK_ANSI_O: self = .o
-        case kVK_ANSI_U: self = .u
-        case kVK_ANSI_LeftBracket: self = .leftBracket
-        case kVK_ANSI_I: self = .i
-        case kVK_ANSI_P: self = .p
-        case kVK_ANSI_L: self = .l
-        case kVK_ANSI_J: self = .j
-        case kVK_ANSI_Quote: self = .quote
-        case kVK_ANSI_K: self = .k
-        case kVK_ANSI_Semicolon: self = .semicolon
-        case kVK_ANSI_Backslash: self = .backslash
-        case kVK_ANSI_Comma: self = .comma
-        case kVK_ANSI_Slash: self = .slash
-        case kVK_ANSI_N: self = .n
-        case kVK_ANSI_M: self = .m
-        case kVK_ANSI_Period: self = .period
-        case kVK_ANSI_Grave: self = .grave
-        case kVK_ANSI_KeypadDecimal: self = .keypadDecimal
-        case kVK_ANSI_KeypadMultiply: self = .keypadMultiply
-        case kVK_ANSI_KeypadPlus: self = .keypadPlus
-        case kVK_ANSI_KeypadClear: self = .keypadClear
-        case kVK_ANSI_KeypadDivide: self = .keypadDivide
-        case kVK_ANSI_KeypadEnter: self = .keypadEnter
-        case kVK_ANSI_KeypadMinus: self = .keypadMinus
-        case kVK_ANSI_KeypadEquals: self = .keypadEquals
-        case kVK_ANSI_Keypad0: self = .keypadZero
-        case kVK_ANSI_Keypad1: self = .keypadOne
-        case kVK_ANSI_Keypad2: self = .keypadTwo
-        case kVK_ANSI_Keypad3: self = .keypadThree
-        case kVK_ANSI_Keypad4: self = .keypadFour
-        case kVK_ANSI_Keypad5: self = .keypadFive
-        case kVK_ANSI_Keypad6: self = .keypadSix
-        case kVK_ANSI_Keypad7: self = .keypadSeven
-        case kVK_ANSI_Keypad8: self = .keypadEight
-        case kVK_ANSI_Keypad9: self = .keypadNine
-        case kVK_Return: self = .return
-        case kVK_Tab: self = .tab
-        case kVK_Space: self = .space
-        case kVK_Delete: self = .delete
-        case kVK_Escape: self = .escape
-        case kVK_F17: self = .f17
-        case kVK_F18: self = .f18
-        case kVK_F19: self = .f19
-        case kVK_F20: self = .f20
-        case kVK_F5: self = .f5
-        case kVK_F6: self = .f6
-        case kVK_F7: self = .f7
-        case kVK_F3: self = .f3
-        case kVK_F8: self = .f8
-        case kVK_F9: self = .f9
-        case kVK_F11: self = .f11
-        case kVK_F13: self = .f13
-        case kVK_F16: self = .f16
-        case kVK_F14: self = .f14
-        case kVK_F10: self = .f10
-        case kVK_F12: self = .f12
-        case kVK_F15: self = .f15
-        case kVK_Help: self = .help
-        case kVK_Home: self = .home
-        case kVK_PageUp: self = .pageUp
-        case kVK_ForwardDelete: self = .forwardDelete
-        case kVK_F4: self = .f4
-        case kVK_End: self = .end
-        case kVK_F2: self = .f2
-        case kVK_PageDown: self = .pageDown
-        case kVK_F1: self = .f1
-        case kVK_LeftArrow: self = .leftArrow
-        case kVK_RightArrow: self = .rightArrow
-        case kVK_DownArrow: self = .downArrow
-        case kVK_UpArrow: self = .upArrow
-        case kVK_JIS_Yen: self = .yen
-        case kVK_JIS_Underscore: self = .underscore
-        case kVK_JIS_KeypadComma: self = .keypadComma
-        case kVK_JIS_Eisu: self = .eisu
-        case kVK_JIS_Kana: self = .kana
+        case kVK_ANSI_A:
+            self = .a
+        case kVK_ANSI_S:
+            self = .s
+        case kVK_ANSI_D:
+            self = .d
+        case kVK_ANSI_F:
+            self = .f
+        case kVK_ANSI_H:
+            self = .h
+        case kVK_ANSI_G:
+            self = .g
+        case kVK_ANSI_Z:
+            self = .z
+        case kVK_ANSI_X:
+            self = .x
+        case kVK_ANSI_C:
+            self = .c
+        case kVK_ANSI_V:
+            self = .v
+        case kVK_ANSI_B:
+            self = .b
+        case kVK_ANSI_Q:
+            self = .q
+        case kVK_ANSI_W:
+            self = .w
+        case kVK_ANSI_E:
+            self = .e
+        case kVK_ANSI_R:
+            self = .r
+        case kVK_ANSI_Y:
+            self = .y
+        case kVK_ANSI_T:
+            self = .t
+        case kVK_ANSI_1:
+            self = .one
+        case kVK_ANSI_2:
+            self = .two
+        case kVK_ANSI_3:
+            self = .three
+        case kVK_ANSI_4:
+            self = .four
+        case kVK_ANSI_6:
+            self = .six
+        case kVK_ANSI_5:
+            self = .five
+        case kVK_ANSI_Equal:
+            self = .equal
+        case kVK_ANSI_9:
+            self = .nine
+        case kVK_ANSI_7:
+            self = .seven
+        case kVK_ANSI_Minus:
+            self = .minus
+        case kVK_ANSI_8:
+            self = .eight
+        case kVK_ANSI_0:
+            self = .zero
+        case kVK_ANSI_RightBracket:
+            self = .rightBracket
+        case kVK_ANSI_O:
+            self = .o
+        case kVK_ANSI_U:
+            self = .u
+        case kVK_ANSI_LeftBracket:
+            self = .leftBracket
+        case kVK_ANSI_I:
+            self = .i
+        case kVK_ANSI_P:
+            self = .p
+        case kVK_ANSI_L:
+            self = .l
+        case kVK_ANSI_J:
+            self = .j
+        case kVK_ANSI_Quote:
+            self = .quote
+        case kVK_ANSI_K:
+            self = .k
+        case kVK_ANSI_Semicolon:
+            self = .semicolon
+        case kVK_ANSI_Backslash:
+            self = .backslash
+        case kVK_ANSI_Comma:
+            self = .comma
+        case kVK_ANSI_Slash:
+            self = .slash
+        case kVK_ANSI_N:
+            self = .n
+        case kVK_ANSI_M:
+            self = .m
+        case kVK_ANSI_Period:
+            self = .period
+        case kVK_ANSI_Grave:
+            self = .grave
+        case kVK_ANSI_KeypadDecimal:
+            self = .keypadDecimal
+        case kVK_ANSI_KeypadMultiply:
+            self = .keypadMultiply
+        case kVK_ANSI_KeypadPlus:
+            self = .keypadPlus
+        case kVK_ANSI_KeypadClear:
+            self = .keypadClear
+        case kVK_ANSI_KeypadDivide:
+            self = .keypadDivide
+        case kVK_ANSI_KeypadEnter:
+            self = .keypadEnter
+        case kVK_ANSI_KeypadMinus:
+            self = .keypadMinus
+        case kVK_ANSI_KeypadEquals:
+            self = .keypadEquals
+        case kVK_ANSI_Keypad0:
+            self = .keypadZero
+        case kVK_ANSI_Keypad1:
+            self = .keypadOne
+        case kVK_ANSI_Keypad2:
+            self = .keypadTwo
+        case kVK_ANSI_Keypad3:
+            self = .keypadThree
+        case kVK_ANSI_Keypad4:
+            self = .keypadFour
+        case kVK_ANSI_Keypad5:
+            self = .keypadFive
+        case kVK_ANSI_Keypad6:
+            self = .keypadSix
+        case kVK_ANSI_Keypad7:
+            self = .keypadSeven
+        case kVK_ANSI_Keypad8:
+            self = .keypadEight
+        case kVK_ANSI_Keypad9:
+            self = .keypadNine
+        case kVK_Return:
+            self = .return
+        case kVK_Tab:
+            self = .tab
+        case kVK_Space:
+            self = .space
+        case kVK_Delete:
+            self = .delete
+        case kVK_Escape:
+            self = .escape
+        case kVK_F17:
+            self = .f17
+        case kVK_F18:
+            self = .f18
+        case kVK_F19:
+            self = .f19
+        case kVK_F20:
+            self = .f20
+        case kVK_F5:
+            self = .f5
+        case kVK_F6:
+            self = .f6
+        case kVK_F7:
+            self = .f7
+        case kVK_F3:
+            self = .f3
+        case kVK_F8:
+            self = .f8
+        case kVK_F9:
+            self = .f9
+        case kVK_F11:
+            self = .f11
+        case kVK_F13:
+            self = .f13
+        case kVK_F16:
+            self = .f16
+        case kVK_F14:
+            self = .f14
+        case kVK_F10:
+            self = .f10
+        case kVK_F12:
+            self = .f12
+        case kVK_F15:
+            self = .f15
+        case kVK_Help:
+            self = .help
+        case kVK_Home:
+            self = .home
+        case kVK_PageUp:
+            self = .pageUp
+        case kVK_ForwardDelete:
+            self = .forwardDelete
+        case kVK_F4:
+            self = .f4
+        case kVK_End:
+            self = .end
+        case kVK_F2:
+            self = .f2
+        case kVK_PageDown:
+            self = .pageDown
+        case kVK_F1:
+            self = .f1
+        case kVK_LeftArrow:
+            self = .leftArrow
+        case kVK_RightArrow:
+            self = .rightArrow
+        case kVK_DownArrow:
+            self = .downArrow
+        case kVK_UpArrow:
+            self = .upArrow
+        case kVK_JIS_Yen:
+            self = .yen
+        case kVK_JIS_Underscore:
+            self = .underscore
+        case kVK_JIS_KeypadComma:
+            self = .keypadComma
+        case kVK_JIS_Eisu:
+            self = .eisu
+        case kVK_JIS_Kana:
+            self = .kana
         // .atSign, .caret, .colon is excluded because it uses a duplicate keycode on JIS keyboard only.
         // For example, .atSign is applied to kVK_ANSI_LeftBracket on a JIS keyboard.
-        case kVK_ISO_Section: self = .section
-        default: return nil
+        case kVK_ISO_Section:
+            self = .section
+        default:
+            return nil
         }
     }
 
     // MARK: - Properties
     public var QWERTYKeyCode: CGKeyCode {
         switch self {
-        case .a: return CGKeyCode(kVK_ANSI_A)
-        case .s: return CGKeyCode(kVK_ANSI_S)
-        case .d: return CGKeyCode(kVK_ANSI_D)
-        case .f: return CGKeyCode(kVK_ANSI_F)
-        case .h: return CGKeyCode(kVK_ANSI_H)
-        case .g: return CGKeyCode(kVK_ANSI_G)
-        case .z: return CGKeyCode(kVK_ANSI_Z)
-        case .x: return CGKeyCode(kVK_ANSI_X)
-        case .c: return CGKeyCode(kVK_ANSI_C)
-        case .v: return CGKeyCode(kVK_ANSI_V)
-        case .b: return CGKeyCode(kVK_ANSI_B)
-        case .q: return CGKeyCode(kVK_ANSI_Q)
-        case .w: return CGKeyCode(kVK_ANSI_W)
-        case .e: return CGKeyCode(kVK_ANSI_E)
-        case .r: return CGKeyCode(kVK_ANSI_R)
-        case .y: return CGKeyCode(kVK_ANSI_Y)
-        case .t: return CGKeyCode(kVK_ANSI_T)
-        case .one: return CGKeyCode(kVK_ANSI_1)
-        case .two: return CGKeyCode(kVK_ANSI_2)
-        case .three: return CGKeyCode(kVK_ANSI_3)
-        case .four: return CGKeyCode(kVK_ANSI_4)
-        case .six: return CGKeyCode(kVK_ANSI_6)
-        case .five: return CGKeyCode(kVK_ANSI_5)
-        case .equal: return CGKeyCode(kVK_ANSI_Equal)
-        case .nine: return CGKeyCode(kVK_ANSI_9)
-        case .seven: return CGKeyCode(kVK_ANSI_7)
-        case .minus: return CGKeyCode(kVK_ANSI_Minus)
-        case .eight: return CGKeyCode(kVK_ANSI_8)
-        case .zero: return CGKeyCode(kVK_ANSI_0)
-        case .rightBracket: return CGKeyCode(kVK_ANSI_RightBracket)
-        case .o: return CGKeyCode(kVK_ANSI_O)
-        case .u: return CGKeyCode(kVK_ANSI_U)
-        case .leftBracket: return CGKeyCode(kVK_ANSI_LeftBracket)
-        case .i: return CGKeyCode(kVK_ANSI_I)
-        case .p: return CGKeyCode(kVK_ANSI_P)
-        case .l: return CGKeyCode(kVK_ANSI_L)
-        case .j: return CGKeyCode(kVK_ANSI_J)
-        case .quote: return CGKeyCode(kVK_ANSI_Quote)
-        case .k: return CGKeyCode(kVK_ANSI_K)
-        case .semicolon: return CGKeyCode(kVK_ANSI_Semicolon)
-        case .backslash: return CGKeyCode(kVK_ANSI_Backslash)
-        case .comma: return CGKeyCode(kVK_ANSI_Comma)
-        case .slash: return CGKeyCode(kVK_ANSI_Slash)
-        case .n: return CGKeyCode(kVK_ANSI_N)
-        case .m: return CGKeyCode(kVK_ANSI_M)
-        case .period: return CGKeyCode(kVK_ANSI_Period)
-        case .grave: return CGKeyCode(kVK_ANSI_Grave)
-        case .keypadDecimal: return CGKeyCode(kVK_ANSI_KeypadDecimal)
-        case .keypadMultiply: return CGKeyCode(kVK_ANSI_KeypadMultiply)
-        case .keypadPlus: return CGKeyCode(kVK_ANSI_KeypadPlus)
-        case .keypadClear: return CGKeyCode(kVK_ANSI_KeypadClear)
-        case .keypadDivide: return CGKeyCode(kVK_ANSI_KeypadDivide)
-        case .keypadEnter: return CGKeyCode(kVK_ANSI_KeypadEnter)
-        case .keypadMinus: return CGKeyCode(kVK_ANSI_KeypadMinus)
-        case .keypadEquals: return CGKeyCode(kVK_ANSI_KeypadEquals)
-        case .keypadZero: return CGKeyCode(kVK_ANSI_Keypad0)
-        case .keypadOne: return CGKeyCode(kVK_ANSI_Keypad1)
-        case .keypadTwo: return CGKeyCode(kVK_ANSI_Keypad2)
-        case .keypadThree: return CGKeyCode(kVK_ANSI_Keypad3)
-        case .keypadFour: return CGKeyCode(kVK_ANSI_Keypad4)
-        case .keypadFive: return CGKeyCode(kVK_ANSI_Keypad5)
-        case .keypadSix: return CGKeyCode(kVK_ANSI_Keypad6)
-        case .keypadSeven: return CGKeyCode(kVK_ANSI_Keypad7)
-        case .keypadEight: return CGKeyCode(kVK_ANSI_Keypad8)
-        case .keypadNine: return CGKeyCode(kVK_ANSI_Keypad9)
-        case .return: return CGKeyCode(kVK_Return)
-        case .tab: return CGKeyCode(kVK_Tab)
-        case .space: return CGKeyCode(kVK_Space)
-        case .delete: return CGKeyCode(kVK_Delete)
-        case .escape: return CGKeyCode(kVK_Escape)
-        case .f17: return CGKeyCode(kVK_F17)
-        case .f18: return CGKeyCode(kVK_F18)
-        case .f19: return CGKeyCode(kVK_F19)
-        case .f20: return CGKeyCode(kVK_F20)
-        case .f5: return CGKeyCode(kVK_F5)
-        case .f6: return CGKeyCode(kVK_F6)
-        case .f7: return CGKeyCode(kVK_F7)
-        case .f3: return CGKeyCode(kVK_F3)
-        case .f8: return CGKeyCode(kVK_F8)
-        case .f9: return CGKeyCode(kVK_F9)
-        case .f11: return CGKeyCode(kVK_F11)
-        case .f13: return CGKeyCode(kVK_F13)
-        case .f16: return CGKeyCode(kVK_F16)
-        case .f14: return CGKeyCode(kVK_F14)
-        case .f10: return CGKeyCode(kVK_F10)
-        case .f12: return CGKeyCode(kVK_F12)
-        case .f15: return CGKeyCode(kVK_F15)
-        case .help: return CGKeyCode(kVK_Help)
-        case .home: return CGKeyCode(kVK_Home)
-        case .pageUp: return CGKeyCode(kVK_PageUp)
-        case .forwardDelete: return CGKeyCode(kVK_ForwardDelete)
-        case .f4: return CGKeyCode(kVK_F4)
-        case .end: return CGKeyCode(kVK_End)
-        case .f2: return CGKeyCode(kVK_F2)
-        case .pageDown: return CGKeyCode(kVK_PageDown)
-        case .f1: return CGKeyCode(kVK_F1)
-        case .leftArrow: return CGKeyCode(kVK_LeftArrow)
-        case .rightArrow: return CGKeyCode(kVK_RightArrow)
-        case .downArrow: return CGKeyCode(kVK_DownArrow)
-        case .upArrow: return CGKeyCode(kVK_UpArrow)
-        case .yen: return CGKeyCode(kVK_JIS_Yen)
-        case .underscore: return CGKeyCode(kVK_JIS_Underscore)
-        case .keypadComma: return CGKeyCode(kVK_JIS_KeypadComma)
-        case .eisu: return CGKeyCode(kVK_JIS_Eisu)
-        case .kana: return CGKeyCode(kVK_JIS_Kana)
-        case .atSign: return CGKeyCode(kVK_ANSI_LeftBracket)
-        case .caret: return CGKeyCode(kVK_ANSI_Equal)
-        case .colon: return CGKeyCode(kVK_ANSI_Quote)
-        case .section: return CGKeyCode(kVK_ISO_Section)
+        case .a:
+            return CGKeyCode(kVK_ANSI_A)
+        case .s:
+            return CGKeyCode(kVK_ANSI_S)
+        case .d:
+            return CGKeyCode(kVK_ANSI_D)
+        case .f:
+            return CGKeyCode(kVK_ANSI_F)
+        case .h:
+            return CGKeyCode(kVK_ANSI_H)
+        case .g:
+            return CGKeyCode(kVK_ANSI_G)
+        case .z:
+            return CGKeyCode(kVK_ANSI_Z)
+        case .x:
+            return CGKeyCode(kVK_ANSI_X)
+        case .c:
+            return CGKeyCode(kVK_ANSI_C)
+        case .v:
+            return CGKeyCode(kVK_ANSI_V)
+        case .b:
+            return CGKeyCode(kVK_ANSI_B)
+        case .q:
+            return CGKeyCode(kVK_ANSI_Q)
+        case .w:
+            return CGKeyCode(kVK_ANSI_W)
+        case .e:
+            return CGKeyCode(kVK_ANSI_E)
+        case .r:
+            return CGKeyCode(kVK_ANSI_R)
+        case .y:
+            return CGKeyCode(kVK_ANSI_Y)
+        case .t:
+            return CGKeyCode(kVK_ANSI_T)
+        case .one:
+            return CGKeyCode(kVK_ANSI_1)
+        case .two:
+            return CGKeyCode(kVK_ANSI_2)
+        case .three:
+            return CGKeyCode(kVK_ANSI_3)
+        case .four:
+            return CGKeyCode(kVK_ANSI_4)
+        case .six:
+            return CGKeyCode(kVK_ANSI_6)
+        case .five:
+            return CGKeyCode(kVK_ANSI_5)
+        case .equal:
+            return CGKeyCode(kVK_ANSI_Equal)
+        case .nine:
+            return CGKeyCode(kVK_ANSI_9)
+        case .seven:
+            return CGKeyCode(kVK_ANSI_7)
+        case .minus:
+            return CGKeyCode(kVK_ANSI_Minus)
+        case .eight:
+            return CGKeyCode(kVK_ANSI_8)
+        case .zero:
+            return CGKeyCode(kVK_ANSI_0)
+        case .rightBracket:
+            return CGKeyCode(kVK_ANSI_RightBracket)
+        case .o:
+            return CGKeyCode(kVK_ANSI_O)
+        case .u:
+            return CGKeyCode(kVK_ANSI_U)
+        case .leftBracket:
+            return CGKeyCode(kVK_ANSI_LeftBracket)
+        case .i:
+            return CGKeyCode(kVK_ANSI_I)
+        case .p:
+            return CGKeyCode(kVK_ANSI_P)
+        case .l:
+            return CGKeyCode(kVK_ANSI_L)
+        case .j:
+            return CGKeyCode(kVK_ANSI_J)
+        case .quote:
+            return CGKeyCode(kVK_ANSI_Quote)
+        case .k:
+            return CGKeyCode(kVK_ANSI_K)
+        case .semicolon:
+            return CGKeyCode(kVK_ANSI_Semicolon)
+        case .backslash:
+            return CGKeyCode(kVK_ANSI_Backslash)
+        case .comma:
+            return CGKeyCode(kVK_ANSI_Comma)
+        case .slash:
+            return CGKeyCode(kVK_ANSI_Slash)
+        case .n:
+            return CGKeyCode(kVK_ANSI_N)
+        case .m:
+            return CGKeyCode(kVK_ANSI_M)
+        case .period:
+            return CGKeyCode(kVK_ANSI_Period)
+        case .grave:
+            return CGKeyCode(kVK_ANSI_Grave)
+        case .keypadDecimal:
+            return CGKeyCode(kVK_ANSI_KeypadDecimal)
+        case .keypadMultiply:
+            return CGKeyCode(kVK_ANSI_KeypadMultiply)
+        case .keypadPlus:
+            return CGKeyCode(kVK_ANSI_KeypadPlus)
+        case .keypadClear:
+            return CGKeyCode(kVK_ANSI_KeypadClear)
+        case .keypadDivide:
+            return CGKeyCode(kVK_ANSI_KeypadDivide)
+        case .keypadEnter:
+            return CGKeyCode(kVK_ANSI_KeypadEnter)
+        case .keypadMinus:
+            return CGKeyCode(kVK_ANSI_KeypadMinus)
+        case .keypadEquals:
+            return CGKeyCode(kVK_ANSI_KeypadEquals)
+        case .keypadZero:
+            return CGKeyCode(kVK_ANSI_Keypad0)
+        case .keypadOne:
+            return CGKeyCode(kVK_ANSI_Keypad1)
+        case .keypadTwo:
+            return CGKeyCode(kVK_ANSI_Keypad2)
+        case .keypadThree:
+            return CGKeyCode(kVK_ANSI_Keypad3)
+        case .keypadFour:
+            return CGKeyCode(kVK_ANSI_Keypad4)
+        case .keypadFive:
+            return CGKeyCode(kVK_ANSI_Keypad5)
+        case .keypadSix:
+            return CGKeyCode(kVK_ANSI_Keypad6)
+        case .keypadSeven:
+            return CGKeyCode(kVK_ANSI_Keypad7)
+        case .keypadEight:
+            return CGKeyCode(kVK_ANSI_Keypad8)
+        case .keypadNine:
+            return CGKeyCode(kVK_ANSI_Keypad9)
+        case .return:
+            return CGKeyCode(kVK_Return)
+        case .tab:
+            return CGKeyCode(kVK_Tab)
+        case .space:
+            return CGKeyCode(kVK_Space)
+        case .delete:
+            return CGKeyCode(kVK_Delete)
+        case .escape:
+            return CGKeyCode(kVK_Escape)
+        case .f17:
+            return CGKeyCode(kVK_F17)
+        case .f18:
+            return CGKeyCode(kVK_F18)
+        case .f19:
+            return CGKeyCode(kVK_F19)
+        case .f20:
+            return CGKeyCode(kVK_F20)
+        case .f5:
+            return CGKeyCode(kVK_F5)
+        case .f6:
+            return CGKeyCode(kVK_F6)
+        case .f7:
+            return CGKeyCode(kVK_F7)
+        case .f3:
+            return CGKeyCode(kVK_F3)
+        case .f8:
+            return CGKeyCode(kVK_F8)
+        case .f9:
+            return CGKeyCode(kVK_F9)
+        case .f11:
+            return CGKeyCode(kVK_F11)
+        case .f13:
+            return CGKeyCode(kVK_F13)
+        case .f16:
+            return CGKeyCode(kVK_F16)
+        case .f14:
+            return CGKeyCode(kVK_F14)
+        case .f10:
+            return CGKeyCode(kVK_F10)
+        case .f12:
+            return CGKeyCode(kVK_F12)
+        case .f15:
+            return CGKeyCode(kVK_F15)
+        case .help:
+            return CGKeyCode(kVK_Help)
+        case .home:
+            return CGKeyCode(kVK_Home)
+        case .pageUp:
+            return CGKeyCode(kVK_PageUp)
+        case .forwardDelete:
+            return CGKeyCode(kVK_ForwardDelete)
+        case .f4:
+            return CGKeyCode(kVK_F4)
+        case .end:
+            return CGKeyCode(kVK_End)
+        case .f2:
+            return CGKeyCode(kVK_F2)
+        case .pageDown:
+            return CGKeyCode(kVK_PageDown)
+        case .f1:
+            return CGKeyCode(kVK_F1)
+        case .leftArrow:
+            return CGKeyCode(kVK_LeftArrow)
+        case .rightArrow:
+            return CGKeyCode(kVK_RightArrow)
+        case .downArrow:
+            return CGKeyCode(kVK_DownArrow)
+        case .upArrow:
+            return CGKeyCode(kVK_UpArrow)
+        case .yen:
+            return CGKeyCode(kVK_JIS_Yen)
+        case .underscore:
+            return CGKeyCode(kVK_JIS_Underscore)
+        case .keypadComma:
+            return CGKeyCode(kVK_JIS_KeypadComma)
+        case .eisu:
+            return CGKeyCode(kVK_JIS_Eisu)
+        case .kana:
+            return CGKeyCode(kVK_JIS_Kana)
+        case .atSign:
+            return CGKeyCode(kVK_ANSI_LeftBracket)
+        case .caret:
+            return CGKeyCode(kVK_ANSI_Equal)
+        case .colon:
+            return CGKeyCode(kVK_ANSI_Quote)
+        case .section:
+            return CGKeyCode(kVK_ISO_Section)
         }
     }
 }

--- a/Sources/Sauce/Key.swift
+++ b/Sources/Sauce/Key.swift
@@ -941,4 +941,6 @@ private extension Key {
         }
     }
 }
+
+// swiftlint:enable file_length function_body_length type_body_length identifier_name
 #endif

--- a/Sources/Sauce/Key.swift
+++ b/Sources/Sauce/Key.swift
@@ -129,6 +129,8 @@ public enum Key: String, Codable, Equatable, Sendable {
 
     // MARK: - Initiazlie
     public init?(character: String, virtualKeyCode: Int?) {
+        guard !character.isEmpty else { return nil }
+
         let lowercasedString = character.lowercased()
         switch lowercasedString {
         case "a":
@@ -255,14 +257,12 @@ public enum Key: String, Codable, Equatable, Sendable {
         case "keypadplus",
             "+":
             self = .keypadPlus
-        case "keypadclear",
-            SpecialKeyCode.keypadClear.character.lowercased():
+        case "keypadclear":
             self = .keypadClear
         case "keypaddivide",
             "/" where virtualKeyCode == kVK_ANSI_KeypadDivide:
             self = .keypadDivide
-        case "keypadenter",
-            SpecialKeyCode.keypadEnter.character.lowercased():
+        case "keypadenter":
             self = .keypadEnter
         case "keypadminus",
             "-" where virtualKeyCode == kVK_ANSI_KeypadMinus:
@@ -310,112 +310,76 @@ public enum Key: String, Codable, Equatable, Sendable {
             "keypadnine",
             "9" where virtualKeyCode == kVK_ANSI_Keypad9:
             self = .keypadNine
-        case "return",
-            "\r", // NSMenuItem.keyEquivalent for return key
-            "\n",
-            SpecialKeyCode.return.character.lowercased():
+        case "return":
             self = .return
-        case "tab",
-            SpecialKeyCode.tab.character.lowercased():
+        case "tab":
             self = .tab
         case "space",
-            SpecialKeyCode.space.character.lowercased():
+            " ":
             self = .space
-        case "delete",
-            SpecialKeyCode.delete.character.lowercased():
+        case "delete":
             self = .delete
-        case "escape",
-            SpecialKeyCode.escape.character.lowercased():
+        case "escape":
             self = .escape
-        case "f17",
-            SpecialKeyCode.f17.character.lowercased():
+        case "f17":
             self = .f17
-        case "f18",
-            SpecialKeyCode.f18.character.lowercased():
+        case "f18":
             self = .f18
-        case "f19",
-            SpecialKeyCode.f19.character.lowercased():
+        case "f19":
             self = .f19
-        case "f20",
-            SpecialKeyCode.f20.character.lowercased():
+        case "f20":
             self = .f20
-        case "f5",
-            SpecialKeyCode.f5.character.lowercased():
+        case "f5":
             self = .f5
-        case "f6",
-            SpecialKeyCode.f6.character.lowercased():
+        case "f6":
             self = .f6
-        case "f7",
-            SpecialKeyCode.f7.character.lowercased():
+        case "f7":
             self = .f7
-        case "f3",
-            SpecialKeyCode.f3.character.lowercased():
+        case "f3":
             self = .f3
-        case "f8",
-            SpecialKeyCode.f8.character.lowercased():
+        case "f8":
             self = .f8
-        case "f9",
-            SpecialKeyCode.f9.character.lowercased():
+        case "f9":
             self = .f9
-        case "f11",
-            SpecialKeyCode.f11.character.lowercased():
+        case "f11":
             self = .f11
-        case "f13",
-            SpecialKeyCode.f13.character.lowercased():
+        case "f13":
             self = .f13
-        case "f16",
-            SpecialKeyCode.f16.character.lowercased():
+        case "f16":
             self = .f16
-        case "f14",
-            SpecialKeyCode.f14.character.lowercased():
+        case "f14":
             self = .f14
-        case "f10",
-            SpecialKeyCode.f10.character.lowercased():
+        case "f10":
             self = .f10
-        case "f12",
-            SpecialKeyCode.f12.character.lowercased():
+        case "f12":
             self = .f12
-        case "f15",
-            SpecialKeyCode.f15.character.lowercased():
+        case "f15":
             self = .f15
-        case "help",
-            SpecialKeyCode.help.character.lowercased():
+        case "help":
             self = .help
-        case "home",
-            SpecialKeyCode.home.character.lowercased():
+        case "home":
             self = .home
-        case "pageup",
-            SpecialKeyCode.pageUp.character.lowercased():
+        case "pageup":
             self = .pageUp
-        case "forwarddelete",
-            SpecialKeyCode.forwardDelete.character.lowercased():
+        case "forwarddelete":
             self = .forwardDelete
-        case "f4",
-            SpecialKeyCode.f4.character.lowercased():
+        case "f4":
             self = .f4
-        case "end",
-            SpecialKeyCode.end.character.lowercased():
+        case "end":
             self = .end
-        case "f2",
-            SpecialKeyCode.f2.character.lowercased():
+        case "f2":
             self = .f2
-        case "pagedown",
-            SpecialKeyCode.pageDown.character.lowercased():
+        case "pagedown":
             self = .pageDown
-        case "f1",
-            SpecialKeyCode.f1.character.lowercased():
+        case "f1":
             self = .f1
-        case "leftarrow",
-            SpecialKeyCode.leftArrow.character.lowercased():
+        case "leftarrow":
             self = .leftArrow
-        case "rightarrow",
-            SpecialKeyCode.rightArrow.character.lowercased():
+        case "rightarrow":
             self = .rightArrow
-        case "downarrow",
-            SpecialKeyCode.downArrow.character.lowercased():
+        case "downarrow":
             self = .downArrow
-        case "uparrow",
-            SpecialKeyCode.upArrow.character.lowercased():
+        case "uparrow":
             self = .upArrow
         case "¥":
             self = .yen
@@ -423,11 +387,9 @@ public enum Key: String, Codable, Equatable, Sendable {
             self = .underscore
         case "," where virtualKeyCode == kVK_JIS_KeypadComma:
             self = .keypadComma
-        case "英数",
-            SpecialKeyCode.eisu.character.lowercased():
+        case "英数":
             self = .eisu
-        case "かな",
-            SpecialKeyCode.kana.character.lowercased():
+        case "かな":
             self = .kana
         case "@":
             self = .atSign
@@ -438,7 +400,14 @@ public enum Key: String, Codable, Equatable, Sendable {
         case "§":
             self = .section
         default:
-            return nil
+            let keyCodes = SpecialKeyCode.allCases
+            if let specialKeyCode = keyCodes.first(where: { $0.character.lowercased() == lowercasedString }) {
+                self = .init(specialKeyCode: specialKeyCode)
+            } else if let specialKeyCode = keyCodes.first(where: { $0.appKitKeyEquivalents.contains(lowercasedString) }) {
+                self = .init(specialKeyCode: specialKeyCode)
+            } else {
+                return nil
+            }
         }
     }
 
@@ -884,6 +853,91 @@ public enum Key: String, Codable, Equatable, Sendable {
             return CGKeyCode(kVK_ANSI_Quote)
         case .section:
             return CGKeyCode(kVK_ISO_Section)
+        }
+    }
+}
+
+private extension Key {
+    init(specialKeyCode: SpecialKeyCode) {
+        switch specialKeyCode {
+        case .return:
+            self = .return
+        case .tab:
+            self = .tab
+        case .space:
+            self = .space
+        case .delete:
+            self = .delete
+        case .escape:
+            self = .escape
+        case .f17:
+            self = .f17
+        case .f18:
+            self = .f18
+        case .f19:
+            self = .f19
+        case .f20:
+            self = .f20
+        case .f5:
+            self = .f5
+        case .f6:
+            self = .f6
+        case .f7:
+            self = .f7
+        case .f3:
+            self = .f3
+        case .f8:
+            self = .f8
+        case .f9:
+            self = .f9
+        case .f11:
+            self = .f11
+        case .f13:
+            self = .f13
+        case .f16:
+            self = .f16
+        case .f14:
+            self = .f14
+        case .f10:
+            self = .f10
+        case .f12:
+            self = .f12
+        case .f15:
+            self = .f15
+        case .help:
+            self = .help
+        case .home:
+            self = .home
+        case .pageUp:
+            self = .pageUp
+        case .forwardDelete:
+            self = .forwardDelete
+        case .f4:
+            self = .f4
+        case .end:
+            self = .end
+        case .f2:
+            self = .f2
+        case .pageDown:
+            self = .pageDown
+        case .f1:
+            self = .f1
+        case .leftArrow:
+            self = .leftArrow
+        case .rightArrow:
+            self = .rightArrow
+        case .downArrow:
+            self = .downArrow
+        case .upArrow:
+            self = .upArrow
+        case .eisu:
+            self = .eisu
+        case .kana:
+            self = .kana
+        case .keypadClear:
+            self = .keypadClear
+        case .keypadEnter:
+            self = .keypadEnter
         }
     }
 }


### PR DESCRIPTION
## Summary

`NSMenuItem.keyEquivalent` expresses layout-independent keys as control characters (`NSTabCharacter`, `NSCarriageReturnCharacter`, `NSEnterCharacter`, ...) and function-key Unicode scalars (`NSF1FunctionKey`...`NSF20FunctionKey`, arrows, Home/End, PageUp/PageDown, etc.), which `Key(character:virtualKeyCode:)` could not parse. This PR adds support for them.

- Add `SpecialKeyCode.appKitKeyEquivalents`, mapping each layout-independent key to the characters AppKit uses for it, and resolve otherwise-unmatched characters through it (display characters such as `↩` are resolved through the same fallback)
- `NSEnterCharacter` (0x03) now resolves to `.keypadEnter`, `NSClearLineFunctionKey` to `.keypadClear`, and `" "` to `.space`
- Refactor `SpecialKeyCode.character` to return character literals instead of building strings with `String(format: "%C", ...)` at runtime
- Whitespace-only reformat of the `Key` switch statements to place case bodies on separate lines

## Test plan

- Existing test suite passes
- Verified against a smoke test covering all pre-existing conversions (`"\r"` / `"\n"`, display characters, F-key names, keypad `where` guards) and the new AppKit equivalents

🤖 Generated with [Claude Code](https://claude.com/claude-code)