### PR TITLE
Fix keypad Enter key code mapping

### DIFF
--- a/Sources/Sauce/Key.swift
+++ b/Sources/Sauce/Key.swift
@@ -403,7 +403,7 @@ public enum Key: String, Codable, Equatable, Sendable {
             let keyCodes = SpecialKeyCode.allCases
             if let specialKeyCode = keyCodes.first(where: { $0.character.lowercased() == lowercasedString }) {
                 self = .init(specialKeyCode: specialKeyCode)
-            } else if let specialKeyCode = keyCodes.first(where: { $0.appKitKeyEquivalents.contains(lowercasedString) }) {
+            } else if virtualKeyCode == nil, let specialKeyCode = keyCodes.first(where: { $0.appKitKeyEquivalents.contains(lowercasedString) }) {
                 self = .init(specialKeyCode: specialKeyCode)
             } else {
                 return nil

--- a/Tests/SauceTests/KeyboardLayoutTests.swift
+++ b/Tests/SauceTests/KeyboardLayoutTests.swift
@@ -54,6 +54,20 @@ final class KeyboardLayoutTests {
     }
 
     @Test(
+        .inputSource(enableIDs: [ABCKeyboardID], selectIDs: [ABCKeyboardID]),
+        .bug("https://github.com/Clipy/Sauce/issues/89")
+    )
+    func keypadEnterUsesCarbonVirtualKeyCode() throws {
+        let sauce = Sauce()
+
+        let keyCode = sauce.keyCode(for: .keypadEnter)
+        #expect(keyCode == CGKeyCode(kVK_ANSI_KeypadEnter))
+
+        let character = try #require(sauce.character(for: Int(keyCode)))
+        #expect(character == "⌅")
+    }
+
+    @Test(
         .inputSource(enableIDs: [ABCKeyboardID, dvorakKeyboardID], selectIDs: [dvorakKeyboardID])
     )
     func keyCodesForDvorakKeyboard() {

--- a/Tests/SauceTests/NSMenuItem+KeyTests.swift
+++ b/Tests/SauceTests/NSMenuItem+KeyTests.swift
@@ -27,4 +27,14 @@ struct NSMenuItemKeyTests {
         menuItem.keyEquivalentModifierMask = .shift
         #expect(menuItem.key == .b)
     }
+
+    @Test(.bug("https://github.com/Clipy/Sauce/pull/88"))
+    func enterKeyEquivalentMapsToKeypadEnter() throws {
+        let enterCharacter = try #require(UnicodeScalar(NSEnterCharacter))
+        let menuItem = NSMenuItem()
+        menuItem.keyEquivalent = String(enterCharacter)
+
+        let key = try #require(menuItem.key)
+        #expect(key == .keypadEnter)
+    }
 }


### PR DESCRIPTION
## Summary

- Restrict AppKit key-equivalent matching to character-only lookups where no virtual key code is available.
- Preserve `NSMenuItem` conversion of `NSEnterCharacter` to `.keypadEnter`.
- Add regression coverage for issue #89 and the AppKit key-equivalent behavior introduced in #88.

Fixes #89.

## Investigation

| Version | `keyCode(for: .keypadEnter)` | `character(for: 52)` | `character(for: 76)` |
| --- | ---: | --- | --- |
| 2.5.0 | 76 | ETX (`U+0003`) | `⌅` |
| 2.5.1 | **52 (incorrect)** | ETX (`U+0003`) | `⌅` |

Strictly speaking, `character(for: 52)` did not regress: it already returned ETX in 2.5.0. The regression was that `.keypadEnter` started resolving to virtual key code 52 instead of the Carbon keypad Enter code 76, so passing that result back to `character(for:)` exposed ETX.

## Root cause

The AppKit key-equivalent support added in 2.5.1 recognizes `NSEnterCharacter` (`U+0003`) as `.keypadEnter`. The macOS keyboard layout translates both the legacy PowerBook Enter virtual key code 52 and the ANSI keypad Enter virtual key code 76 to `U+0003`.

`KeyboardLayout` scans virtual key codes from 0 through 127 and keeps the first mapping found for each `Key`. Once `Key.init(character:virtualKeyCode:)` began accepting AppKit key-equivalent characters during that scan, code 52 was classified as `.keypadEnter` before code 76 was reached. The first mapping therefore won.

AppKit key-equivalent strings are needed for character-only APIs such as `NSMenuItem.keyEquivalent`, where no virtual key code is available. The fix limits that matching to `virtualKeyCode == nil`, preventing legacy layout aliases from overriding the physical Carbon key code while retaining the intended menu-item behavior.

The full Swift test suite passes with 9 tests, including the new issue #89 regression test.